### PR TITLE
Fix crash in Auth when running unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,10 @@ default.profraw
 *.tfstate
 *.tfstate.*
 *.xcuserstate
+
+
+#firebase-ios-sdk clone
+firebase-ios-sdk/
+
+#scripts link
+scripts

--- a/Tests/Unit/InstanceTests.swift
+++ b/Tests/Unit/InstanceTests.swift
@@ -55,7 +55,6 @@ class InstanceTests: XCTestCase {
     FirebaseApp.configure(options: options)
     defaultApp = FirebaseApp.app()
 
-
     FirebaseApp.configure(name: "app-two", options: optionsTwo)
     appTwo = FirebaseApp.app(name: "app-two")
   }

--- a/Tests/Unit/InstanceTests.swift
+++ b/Tests/Unit/InstanceTests.swift
@@ -19,8 +19,26 @@ import XCTest
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 class InstanceTests: XCTestCase {
-  var defaultApp: FirebaseApp?
-  var appTwo: FirebaseApp?
+  static var defaultApp: FirebaseApp?
+  static var appTwo: FirebaseApp?
+
+  static var options: FirebaseOptions = {
+    let options = FirebaseOptions(googleAppID: "0:0000000000000:ios:0000000000000000",
+                                  gcmSenderID: "00000000000000000-00000000000-000000000")
+    options.projectID = "fdc-test"
+    options.apiKey = "testDummyApiKey"
+    return options
+  }()
+
+  static var optionsTwo: FirebaseOptions = {
+    let optionsTwo = FirebaseOptions(
+      googleAppID: "0:0000000000001:ios:0000000000000001",
+      gcmSenderID: "00000000000000000-00000000000-000000001"
+    )
+    optionsTwo.projectID = "fdc-test"
+    optionsTwo.apiKey = "testDummyApiKey2"
+    return optionsTwo
+  }()
 
   var fakeConnectorConfigOne = ConnectorConfig(
     serviceId: "dataconnect",
@@ -33,18 +51,11 @@ class InstanceTests: XCTestCase {
     connector: "blogs"
   )
 
-  override func setUp() {
-    let options = FirebaseOptions(googleAppID: "0:0000000000000:ios:0000000000000000",
-                                  gcmSenderID: "00000000000000000-00000000000-000000000")
-    options.projectID = "fdc-test"
+  override class func setUp() {
     FirebaseApp.configure(options: options)
     defaultApp = FirebaseApp.app()
 
-    let optionsTwo = FirebaseOptions(
-      googleAppID: "0:0000000000001:ios:0000000000000001",
-      gcmSenderID: "00000000000000000-00000000000-000000001"
-    )
-    optionsTwo.projectID = "fdc-test"
+
     FirebaseApp.configure(name: "app-two", options: optionsTwo)
     appTwo = FirebaseApp.app(name: "app-two")
   }
@@ -62,7 +73,10 @@ class InstanceTests: XCTestCase {
   // same connector config, different apps, instances should be different
   func testDifferentInstanceDifferentApps() throws {
     let dcOne = DataConnect.dataConnect(connectorConfig: fakeConnectorConfigOne)
-    let dcTwo = DataConnect.dataConnect(app: appTwo, connectorConfig: fakeConnectorConfigTwo)
+    let dcTwo = DataConnect.dataConnect(
+      app: InstanceTests.appTwo,
+      connectorConfig: fakeConnectorConfigTwo
+    )
 
     let isDifferent = dcOne !== dcTwo
     XCTAssertTrue(isDifferent)


### PR DESCRIPTION
Fixes the crash in Auth when running Unit Tests. This is because the Auth SDK expects an API key in 11.x SDK. The tests were not supplying a dummy key. 