### PR TITLE
Implement userAgent for Data Connect

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -33,6 +33,8 @@ jobs:
         target: [iOS, tvOS, macOS, catalyst, visionOS]
         xcode: [Xcode_15.2, Xcode_15.4, Xcode_16_Release_Candidate]
     runs-on: ${{ matrix.os }}
+    env:
+      FIREBASE_MAIN: 1
     steps:
     - uses: actions/checkout@v4
     - name: Xcode

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,6 @@
 import class Foundation.ProcessInfo
 import PackageDescription
 
-// let firebaseVersion = "10.25.0"
-
 let package = Package(
   name: "FirebaseDataConnect",
   platforms: [.iOS(.v12), .macCatalyst(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v7)],
@@ -32,7 +30,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/firebase/firebase-ios-sdk",
-             from: "11.0.0"),
+             branch: "nc/demo-reg"),
     .package(
       url: "https://github.com/grpc/grpc-swift.git",
       from: "1.19.1" // TODO: Constrain to a range at time of release

--- a/Package.swift
+++ b/Package.swift
@@ -29,8 +29,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/firebase/firebase-ios-sdk",
-             branch: "nc/demo-reg"),
+    firebaseDependency(),
     .package(
       url: "https://github.com/grpc/grpc-swift.git",
       from: "1.19.1" // TODO: Constrain to a range at time of release
@@ -41,6 +40,8 @@ let package = Package(
       name: "FirebaseDataConnect",
       dependencies: [
         .product(name: "GRPC", package: "grpc-swift"),
+        .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
+        // TODO: Investigate switching Auth and AppCheck to interop.
         .product(name: "FirebaseAuth", package: "firebase-ios-sdk"),
         .product(name: "FirebaseAppCheck", package: "firebase-ios-sdk"),
 
@@ -54,3 +55,15 @@ let package = Package(
     ),
   ]
 )
+
+func firebaseDependency() -> Package.Dependency {
+  let firebaseURL = "https://github.com/firebase/firebase-ios-sdk"
+
+  // Point SPM CI to the tip of main of https://github.com/firebase/firebase-ios-sdk so that the
+  // release process can defer publishing the GoogleAppMeasurement tag until after testing.
+  if ProcessInfo.processInfo.environment["FIREBASE_MAIN"] != nil {
+    return .package(url: firebaseURL, branch: "main")
+  }
+
+  return .package(url: firebaseURL, exact: "11.3.0")
+}

--- a/Sources/DataConnectSettings.swift
+++ b/Sources/DataConnectSettings.swift
@@ -16,7 +16,6 @@ import Foundation
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct DataConnectSettings: Hashable, Equatable {
-  static let version = "11.3.0-beta"
   public private(set) var host: String
   public private(set) var port: Int
   public private(set) var sslEnabled: Bool

--- a/Sources/DataConnectSettings.swift
+++ b/Sources/DataConnectSettings.swift
@@ -16,6 +16,7 @@ import Foundation
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct DataConnectSettings: Hashable, Equatable {
+  static let version = "11.3.0-beta"
   public private(set) var host: String
   public private(set) var port: Int
   public private(set) var sslEnabled: Bool

--- a/Sources/Internal/Component.swift
+++ b/Sources/Internal/Component.swift
@@ -1,0 +1,23 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Class for registration with the Firebase component system, including userAgent functionality.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@objc(FIRDataConnectComponent) class DataConnectComponent: NSObject {
+  @objc class func sdkVersion() -> String {
+    return DataConnectSettings.version
+  }
+}

--- a/Sources/Internal/Version.swift
+++ b/Sources/Internal/Version.swift
@@ -14,10 +14,7 @@
 
 import Foundation
 
-/// Class for registration with the Firebase component system, including userAgent functionality.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-@objc(FIRDataConnectComponent) class DataConnectComponent: NSObject {
-  @objc class func sdkVersion() -> String {
-    return Version.version
-  }
+struct Version {
+  static let version = "11.3.0-beta"
 }

--- a/Tests/Unit/UserAgentTests.swift
+++ b/Tests/Unit/UserAgentTests.swift
@@ -19,25 +19,22 @@ import FirebaseCore
 @testable import FirebaseDataConnect
 
 final class UserAgentTests: XCTestCase {
-  static var defaultApp: FirebaseApp?
-
   static var options: FirebaseOptions = {
     let options = FirebaseOptions(googleAppID: "0:0000000000000:ios:0000000000000000",
                                   gcmSenderID: "00000000000000000-00000000000-000000000")
-    options.projectID = "fdc-test"
-    options.apiKey = "testDummyApiKey"
+    options.projectID = "user-agent-test"
+    options.apiKey = "testUserAgentDummyApiKey"
     return options
   }()
 
   override class func setUp() {
-    FirebaseApp.configure(options: options)
-    defaultApp = FirebaseApp.app()
+    FirebaseApp.configure(name: "user-agent", options: options)
   }
 
   /// Confirm that Data Connect gets added to the user agent.
   func testUserAgent() {
     let userAgent = FirebaseApp.firebaseUserAgent()
-    let version = DataConnectSettings.version
+    let version = Version.version
     XCTAssertTrue(userAgent.contains("fire-dc/\(version)"))
   }
 }

--- a/Tests/Unit/UserAgentTests.swift
+++ b/Tests/Unit/UserAgentTests.swift
@@ -1,0 +1,43 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import XCTest
+
+import FirebaseCore
+@testable import FirebaseDataConnect
+
+final class UserAgentTests: XCTestCase {
+  static var defaultApp: FirebaseApp?
+
+  static var options: FirebaseOptions = {
+    let options = FirebaseOptions(googleAppID: "0:0000000000000:ios:0000000000000000",
+                                  gcmSenderID: "00000000000000000-00000000000-000000000")
+    options.projectID = "fdc-test"
+    options.apiKey = "testDummyApiKey"
+    return options
+  }()
+
+  override class func setUp() {
+    FirebaseApp.configure(options: options)
+    defaultApp = FirebaseApp.app()
+  }
+
+  /// Confirm that Data Connect gets added to the user agent.
+  func testUserAgent() {
+    let userAgent = FirebaseApp.firebaseUserAgent()
+    let version = DataConnectSettings.version
+    XCTAssertTrue(userAgent.contains("fire-dc/\(version)"))
+  }
+}


### PR DESCRIPTION
Add userAgent support and tests (it relies on unreleased until 11.3.0 Firebase main)

Add environment variable support to use Firebase main instead of a released version.

To develop going forward, close Xcode and restart with `FIREBASE_MAIN=yes open Package.swift`

