### PR TITLE
Fix build warnings

### DIFF
--- a/Sources/Internal/OperationsManager.swift
+++ b/Sources/Internal/OperationsManager.swift
@@ -27,7 +27,7 @@ class OperationsManager {
                                      with resultType: ResultDataType
                                        .Type,
                                      publisher: ResultsPublisherType = .auto)
-  -> any ObservableQueryRef {
+    -> any ObservableQueryRef {
     switch publisher {
     case .auto, .observableMacro:
       if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {

--- a/Sources/Internal/OperationsManager.swift
+++ b/Sources/Internal/OperationsManager.swift
@@ -27,7 +27,7 @@ class OperationsManager {
                                      with resultType: ResultDataType
                                        .Type,
                                      publisher: ResultsPublisherType = .auto)
-    -> any ObservableQueryRef {
+  -> any ObservableQueryRef {
     switch publisher {
     case .auto, .observableMacro:
       if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
@@ -35,20 +35,20 @@ class OperationsManager {
           request: request,
           dataType: resultType,
           grpcClient: self.grpcClient
-        ) as! (any ObservableQueryRef)
+        ) as (any ObservableQueryRef)
       } else {
         return QueryRefObservableObject<ResultDataType, VariableType>(
           request: request,
           dataType: resultType,
           grpcClient: grpcClient
-        ) as! (any ObservableQueryRef)
+        ) as (any ObservableQueryRef)
       }
     case .observableObject:
       return QueryRefObservableObject<ResultDataType, VariableType>(
         request: request,
         dataType: resultType,
         grpcClient: grpcClient
-      ) as! (any ObservableQueryRef)
+      ) as (any ObservableQueryRef)
     }
   }
 

--- a/Sources/ProtoGen/connector_service.grpc.swift
+++ b/Sources/ProtoGen/connector_service.grpc.swift
@@ -272,7 +272,7 @@ public struct Google_Firebase_Dataconnect_V1alpha_ConnectorServiceNIOClient: Goo
 
 #endif // compiler(>=5.6)
 
-public protocol Google_Firebase_Dataconnect_V1alpha_ConnectorServiceClientInterceptorFactoryProtocol: GRPCSendable {
+public protocol Google_Firebase_Dataconnect_V1alpha_ConnectorServiceClientInterceptorFactoryProtocol: Swift.Sendable {
   /// - Returns: Interceptors to use when invoking 'executeQuery'.
   func makeExecuteQueryInterceptors() -> [ClientInterceptor<
     Google_Firebase_Dataconnect_V1alpha_ExecuteQueryRequest,

--- a/Sources/ProtoGen/connector_service.grpc.swift
+++ b/Sources/ProtoGen/connector_service.grpc.swift
@@ -272,7 +272,8 @@ public struct Google_Firebase_Dataconnect_V1alpha_ConnectorServiceNIOClient: Goo
 
 #endif // compiler(>=5.6)
 
-public protocol Google_Firebase_Dataconnect_V1alpha_ConnectorServiceClientInterceptorFactoryProtocol: Swift.Sendable {
+public protocol Google_Firebase_Dataconnect_V1alpha_ConnectorServiceClientInterceptorFactoryProtocol:
+  Swift.Sendable {
   /// - Returns: Interceptors to use when invoking 'executeQuery'.
   func makeExecuteQueryInterceptors() -> [ClientInterceptor<
     Google_Firebase_Dataconnect_V1alpha_ExecuteQueryRequest,


### PR DESCRIPTION
Address four out of five build warnings with Xcode 16.

I'm not sure about how to change the proto generation to change `GRPCSendable` to `Swift.Sendable`

I'm not sure how to fix the following. 

![Screenshot 2024-09-19 at 3 45 34 PM](https://github.com/user-attachments/assets/21d93432-1779-4762-b8e9-cfd86faf4319)
