### PR TITLE
Insert Goog-Api-Client Header

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,10 @@ let package = Package(
       url: "https://github.com/grpc/grpc-swift.git",
       from: "1.19.1" // TODO: Constrain to a range at time of release
     ),
+    .package(
+      url: "https://github.com/google/GoogleUtilities.git",
+      "8.0.0" ..< "9.0.0"
+    ),
   ],
   targets: [
     .target(
@@ -44,7 +48,7 @@ let package = Package(
         // TODO: Investigate switching Auth and AppCheck to interop.
         .product(name: "FirebaseAuth", package: "firebase-ios-sdk"),
         .product(name: "FirebaseAppCheck", package: "firebase-ios-sdk"),
-
+        .product(name: "GULEnvironment", package: "GoogleUtilities"),
       ],
       path: "Sources"
     ),

--- a/Sources/Internal/Component.swift
+++ b/Sources/Internal/Component.swift
@@ -18,6 +18,6 @@ import Foundation
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 @objc(FIRDataConnectComponent) class DataConnectComponent: NSObject {
   @objc class func sdkVersion() -> String {
-    return Version.version
+    return Version.sdkVersion
   }
 }

--- a/Sources/Internal/GrpcClient.swift
+++ b/Sources/Internal/GrpcClient.swift
@@ -77,7 +77,7 @@ actor GrpcClient: CustomStringConvertible {
 
   private lazy var googApiClientHeaderValue: String = {
     let header =
-      "gl-swift/\(Version.swiftMajorVersion()) fire/\(Version.sdkVersion) \(Version.platformVersionHeader()) grpc-swift/"
+      "gl-swift/\(Version.swiftVersion()) fire/\(Version.sdkVersion) \(Version.platformVersionHeader()) grpc-swift/"
 
     switch self.callerSDKType {
     case .base:

--- a/Sources/Internal/GrpcClient.swift
+++ b/Sources/Internal/GrpcClient.swift
@@ -44,11 +44,14 @@ actor GrpcClient: CustomStringConvertible {
 
   private let appCheck: AppCheck?
 
+  private let callerSDKType: CallerSDKType
+
   enum RequestHeaders {
     static let googRequestParamsHeader = "x-goog-request-params"
     static let authorizationHeader = "x-firebase-auth-token"
     static let appCheckHeader = "X-Firebase-AppCheck"
     static let firebaseAppId = "x-firebase-gmpid"
+    static let googApiClient = "x-goog-api-client"
   }
 
   private let googRequestHeaderValue: String
@@ -72,9 +75,23 @@ actor GrpcClient: CustomStringConvertible {
     }
   }()
 
+  private lazy var googApiClientHeaderValue: String = {
+    let header =
+      "gl-swift/\(Version.swiftMajorVersion()) fire/\(Version.sdkVersion) \(Version.platformVersionHeader()) grpc-swift/"
+
+    switch self.callerSDKType {
+    case .base:
+      return header
+    case .generated:
+      return "\(header) swift/gen"
+    }
+
+  }()
+
   init(app: FirebaseApp, settings: DataConnectSettings, connectorConfig: ConnectorConfig,
        auth: Auth,
-       appCheck: AppCheck?) {
+       appCheck: AppCheck?,
+       callerSDKType: CallerSDKType) {
     self.app = app
 
     guard let projectId = app.options.projectID else {
@@ -86,6 +103,7 @@ actor GrpcClient: CustomStringConvertible {
     self.connectorConfig = connectorConfig
     self.auth = auth
     self.appCheck = appCheck
+    self.callerSDKType = callerSDKType
 
     connectorName =
       "projects/\(projectId)/locations/\(connectorConfig.location)/services/\(connectorConfig.serviceId)/connectors/\(connectorConfig.connector)"
@@ -187,6 +205,7 @@ actor GrpcClient: CustomStringConvertible {
 
     headers.add(name: RequestHeaders.googRequestParamsHeader, value: googRequestHeaderValue)
     headers.add(name: RequestHeaders.firebaseAppId, value: app.options.googleAppID)
+    headers.add(name: RequestHeaders.googApiClient, value: googApiClientHeaderValue)
 
     // Add Auth token if available
     do {

--- a/Sources/Internal/Version.swift
+++ b/Sources/Internal/Version.swift
@@ -16,5 +16,41 @@ import Foundation
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct Version {
-  static let version = "11.3.0-beta"
+  static let sdkVersion = "11.3.0-beta"
+
+  // returns value of form gl-PLATFORM_NAME/PLATFORM_VERSION
+  static func platformVersionHeader() -> String {
+    let version = ProcessInfo.processInfo.operatingSystemVersion
+    let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    #if os(iOS)
+      return "gl-ios/\(versionString)"
+    #elseif os(watchOS)
+      return "gl-watchos/\(versionString)"
+    #elseif os(tvOS)
+      return "gl-tvos/\(versionString)"
+    #elseif os(macOS)
+      return "gl-macos/\(versionString)"
+    #else
+      return ""
+    #endif
+  }
+
+  // returns the build time major version of swift
+  static func swiftMajorVersion() -> String {
+    #if swift(>=6)
+      return "6"
+    #elseif swift(>=5)
+      return "5"
+    #elseif swift(>=4)
+      return "4"
+    #elseif swift(>=3)
+      return "3"
+    #elseif swift(>=2)
+      return "2"
+    #elseif swift(>=1)
+      return "1"
+    #else
+      return ""
+    #endif
+  }
 }

--- a/Sources/Internal/Version.swift
+++ b/Sources/Internal/Version.swift
@@ -29,19 +29,51 @@ struct Version {
   }
 
   // returns the build time major version of swift
-  static func swiftMajorVersion() -> String {
+  static func swiftVersion() -> String {
     #if swift(>=6)
       return "6"
-    #elseif swift(>=5)
-      return "5"
-    #elseif swift(>=4)
-      return "4"
-    #elseif swift(>=3)
-      return "3"
-    #elseif swift(>=2)
-      return "2"
-    #elseif swift(>=1)
-      return "1"
+    #elseif swift(>=5.10)
+      return "5.10"
+    #elseif swift(>=5.9)
+      return "5.9"
+    #elseif swift(>=5.8)
+      return "5.8"
+    #elseif swift(>=5.7)
+      return "5.7"
+    #elseif swift(>=5.6)
+      return "5.6"
+    #elseif swift(>=5.5)
+      return "5.5"
+    #elseif swift(>=5.4)
+      return "5.4"
+    #elseif swift(>=5.2)
+      return "5.2"
+    #elseif swift(>=5.1)
+      return "5.1"
+    #elseif swift(>=5.0)
+      return "5.0"
+    #elseif swift(>=4.2)
+      return "4.2"
+    #elseif swift(>=4.1)
+      return "4.1"
+    #elseif swift(>=4.0)
+      return "4.0"
+    #elseif swift(>=3.1)
+      return "3.1"
+    #elseif swift(>=3.0)
+      return "3.0"
+    #elseif swift(>=2.2)
+      return "2.2"
+    #elseif swift(>=2.1)
+      return "2.1"
+    #elseif swift(>=2.0)
+      return "2.0"
+    #elseif swift(>=1.2)
+      return "1.2"
+    #elseif swift(>=1.1)
+      return "1.1"
+    #elseif swift(>=1.0)
+      return "1.0"
     #else
       return ""
     #endif

--- a/Sources/Internal/Version.swift
+++ b/Sources/Internal/Version.swift
@@ -14,25 +14,18 @@
 
 import Foundation
 
+import GoogleUtilities_Environment
+
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct Version {
   static let sdkVersion = "11.3.0-beta"
 
   // returns value of form gl-PLATFORM_NAME/PLATFORM_VERSION
   static func platformVersionHeader() -> String {
-    let version = ProcessInfo.processInfo.operatingSystemVersion
-    let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
-    #if os(iOS)
-      return "gl-ios/\(versionString)"
-    #elseif os(watchOS)
-      return "gl-watchos/\(versionString)"
-    #elseif os(tvOS)
-      return "gl-tvos/\(versionString)"
-    #elseif os(macOS)
-      return "gl-macos/\(versionString)"
-    #else
-      return ""
-    #endif
+    let versionString = GULAppEnvironmentUtil.systemVersion()
+    let platformName = GULAppEnvironmentUtil.applePlatform()
+
+    return "gl-\(platformName)/\(versionString)"
   }
 
   // returns the build time major version of swift

--- a/Tests/Unit/HeaderTests.swift
+++ b/Tests/Unit/HeaderTests.swift
@@ -63,10 +63,6 @@ final class HeaderTests: XCTestCase {
     let values = callOptions.customMetadata.values(
       forHeader: GrpcClient.RequestHeaders.googApiClient, canonicalForm: false
     )
-    for value in values {
-      print("value \(value)")
-    }
-    print("values \(values)")
     let contains = values
       .contains {
         $0 ==
@@ -84,9 +80,6 @@ final class HeaderTests: XCTestCase {
     let values = callOptions.customMetadata.values(
       forHeader: GrpcClient.RequestHeaders.googApiClient, canonicalForm: false
     )
-    for value in values {
-      print("value \(value)")
-    }
     let contains = values
       .contains {
         $0 ==

--- a/Tests/Unit/HeaderTests.swift
+++ b/Tests/Unit/HeaderTests.swift
@@ -66,7 +66,7 @@ final class HeaderTests: XCTestCase {
     let contains = values
       .contains {
         $0 ==
-          "gl-swift/\(Version.swiftMajorVersion()) fire/\(Version.sdkVersion) \(Version.platformVersionHeader()) grpc-swift/"
+          "gl-swift/\(Version.swiftVersion()) fire/\(Version.sdkVersion) \(Version.platformVersionHeader()) grpc-swift/"
       }
     XCTAssertTrue(contains)
   }
@@ -83,7 +83,7 @@ final class HeaderTests: XCTestCase {
     let contains = values
       .contains {
         $0 ==
-          "gl-swift/\(Version.swiftMajorVersion()) fire/\(Version.sdkVersion) \(Version.platformVersionHeader()) grpc-swift/ swift/gen"
+          "gl-swift/\(Version.swiftVersion()) fire/\(Version.sdkVersion) \(Version.platformVersionHeader()) grpc-swift/ swift/gen"
       }
     XCTAssertTrue(contains)
   }

--- a/Tests/Unit/UserAgentTests.swift
+++ b/Tests/Unit/UserAgentTests.swift
@@ -34,7 +34,7 @@ final class UserAgentTests: XCTestCase {
   /// Confirm that Data Connect gets added to the user agent.
   func testUserAgent() {
     let userAgent = FirebaseApp.firebaseUserAgent()
-    let version = Version.version
+    let version = Version.sdkVersion
     XCTAssertTrue(userAgent.contains("fire-dc/\(version)"))
   }
 }


### PR DESCRIPTION
Insert goog-api-client header, which includes a marker if gen sdk is used to call the base sdk. 