### PR TITLE
Restore GHA matrix with SPM cache

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -26,7 +26,7 @@ jobs:
   spm-package-resolved:
     runs-on: macos-14
     outputs:
-      cache-primary-key: ${{ steps.cache.outputs.cache-primary-key }}
+      cache_key: ${{ steps.generate_cache_key.outputs.cache_key }}
     env:
       FIREBASE_MAIN: 1
       DISABLE_INTEGRATION_TESTS: 1
@@ -36,6 +36,11 @@ jobs:
         id: swift_package_resolve
         run: |
           swift package resolve
+      - name: Generate cache key
+        id: generate_cache_key
+        run: |
+          cache_key="${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}"
+          echo "cache_key=${cache_key}" >> "$GITHUB_OUTPUT"
       - uses: actions/cache/save@v4
         id: cache
         with:
@@ -60,7 +65,7 @@ jobs:
     - uses: actions/cache/restore@v4
       with:
         path: .build
-        key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.cache-primary-key}}
+        key: ${{needs.spm-package-resolved.outputs.cache_key}}
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Setup Scripts Directory

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -65,7 +65,5 @@ jobs:
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Setup Scripts Directory
       run: ./setup-scripts.sh
-    - name: Initialize xcodebuild
-      run: xcodebuild -list
-    - name: iOS Unit Tests
+    - name: Unit Tests
       run: scripts/third_party/travis/retry.sh scripts/build.sh FirebaseDataConnect ${{ matrix.target }} spm

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -43,7 +43,7 @@ jobs:
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
 
   spm:
-    needs: changed_today, spm-package-resolved
+    needs: [changed_today, spm-package-resolved]
     if: ${{ github.event_name == 'pull_request' || needs.changed_today.outputs.WAS_CHANGED == 'true' }}
 
     strategy:

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -23,6 +23,25 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         run: echo '::set-output name=WAS_CHANGED::'$(test -n "$(git log --format=%H --since='24 hours ago')" && echo 'true' || echo 'false')
 
+
+  spm-package-resolved:
+    runs-on: macos-14
+    outputs:
+      package_resolved_hash: ${{ steps.cache.outputs.cache-primary-key }}
+    env:
+      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate Swift Package.resolved
+        id: swift_package_resolve
+        run: |
+          swift package resolve
+      - uses: actions/cache/save@v4
+        id: cache
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+
   spm:
     needs: changed_today
     if: ${{ github.event_name == 'pull_request' || needs.changed_today.outputs.WAS_CHANGED == 'true' }}
@@ -31,13 +50,18 @@ jobs:
       matrix:
         os: [macos-14]
         target: [iOS, tvOS, macOS, catalyst, visionOS]
-        xcode: [Xcode_15.2, Xcode_15.4, Xcode_16_Release_Candidate]
+        xcode: [Xcode_15.2, Xcode_15.4, Xcode_16]
     runs-on: ${{ matrix.os }}
+    needs: spm-package-resolved
     env:
       FIREBASE_MAIN: 1
       DISABLE_INTEGRATION_TESTS: 1
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/cache/restore@v4
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.package_resolved_hash}}
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Setup Scripts Directory

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -30,26 +30,19 @@ jobs:
     strategy:
       matrix:
         os: [macos-14]
-        # Target and Xcode matrix commented to workaround GHA download overload crashes
-        # target: [iOS, tvOS, macOS, catalyst, visionOS]
-        # xcode: [Xcode_15.2, Xcode_16_Release_Candidate]
+        target: [iOS, tvOS, macOS, catalyst, visionOS]
+        xcode: [Xcode_15.2, Xcode_15.4, Xcode_16_Release_Candidate]
     runs-on: ${{ matrix.os }}
     env:
       FIREBASE_MAIN: 1
       DISABLE_INTEGRATION_TESTS: 1
     steps:
     - uses: actions/checkout@v4
+    - name: Xcode
+      run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Setup Scripts Directory
       run: ./setup-scripts.sh
-    - name: Xcode 15
-      run: sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh scripts/build.sh FirebaseDataConnect iOS spm
-    - name: tvOS Unit Tests
-      run: scripts/third_party/travis/retry.sh scripts/build.sh FirebaseDataConnect tvOS spm
-    - name: macOS Unit Tests
-      run: scripts/third_party/travis/retry.sh scripts/build.sh FirebaseDataConnect macOS spm
-    - name: visionOS Unit Tests
-      run: scripts/third_party/travis/retry.sh scripts/build.sh FirebaseDataConnect visionOS spm
+      run: scripts/third_party/travis/retry.sh scripts/build.sh FirebaseDataConnect ${{ matrix.target }} spm

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -23,13 +23,13 @@ jobs:
         if: ${{ github.event_name == 'schedule' }}
         run: echo '::set-output name=WAS_CHANGED::'$(test -n "$(git log --format=%H --since='24 hours ago')" && echo 'true' || echo 'false')
 
-
   spm-package-resolved:
     runs-on: macos-14
     outputs:
       package_resolved_hash: ${{ steps.cache.outputs.cache-primary-key }}
     env:
-      FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1
+      FIREBASE_MAIN: 1
+      DISABLE_INTEGRATION_TESTS: 1
     steps:
       - uses: actions/checkout@v4
       - name: Generate Swift Package.resolved

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -43,7 +43,7 @@ jobs:
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
 
   spm:
-    needs: changed_today
+    needs: changed_today, spm-package-resolved
     if: ${{ github.event_name == 'pull_request' || needs.changed_today.outputs.WAS_CHANGED == 'true' }}
 
     strategy:
@@ -52,7 +52,6 @@ jobs:
         target: [iOS, tvOS, macOS, catalyst, visionOS]
         xcode: [Xcode_15.2, Xcode_15.4, Xcode_16]
     runs-on: ${{ matrix.os }}
-    needs: spm-package-resolved
     env:
       FIREBASE_MAIN: 1
       DISABLE_INTEGRATION_TESTS: 1

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -26,7 +26,7 @@ jobs:
   spm-package-resolved:
     runs-on: macos-14
     outputs:
-      package_resolved_hash: ${{ steps.cache.outputs.cache-primary-key }}
+      cache-primary-key: ${{ steps.cache.outputs.cache-primary-key }}
     env:
       FIREBASE_MAIN: 1
       DISABLE_INTEGRATION_TESTS: 1
@@ -60,7 +60,7 @@ jobs:
     - uses: actions/cache/restore@v4
       with:
         path: .build
-        key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.package_resolved_hash}}
+        key: ${{ runner.os }}-spm-${{needs.spm-package-resolved.outputs.cache-primary-key}}
     - name: Xcode
       run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer
     - name: Setup Scripts Directory


### PR DESCRIPTION
Thanks to @andrewheard, this is a better solution to the GHA network failures installing SPM binary packages done in #11.

We're running the full matrix of 15 tests in 11 minutes instead of 13 minutes for 4 tests after #11.

The visionOS tests still seem to run, but may need to change to spmbuildonly based on https://github.com/actions/runner-images/pull/10652