### PR TITLE
Adjust Visibility of OperationRequest and related APIs

### DIFF
--- a/Sources/BaseOperationRef.swift
+++ b/Sources/BaseOperationRef.swift
@@ -24,7 +24,7 @@ public struct OperationResult<ResultData: Decodable> {
 public protocol OperationVariable: Encodable, Hashable, Equatable {}
 
 @available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
-public protocol OperationRequest {
+protocol OperationRequest {
   associatedtype Variable: OperationVariable
   var operationName: String { get } // Name within Connector definition
   var variables: Variable? { get }

--- a/Sources/Internal/Codec.swift
+++ b/Sources/Internal/Codec.swift
@@ -17,9 +17,9 @@ import Foundation
 import SwiftProtobuf
 
 @available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
-public typealias FirebaseDataConnectExecuteMutationRequest =
+typealias FirebaseDataConnectExecuteMutationRequest =
   Google_Firebase_Dataconnect_V1beta_ExecuteMutationRequest
-public typealias FirebaseDataConnectExecuteQueryRequest =
+typealias FirebaseDataConnectExecuteQueryRequest =
   Google_Firebase_Dataconnect_V1beta_ExecuteQueryRequest
 
 @available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)

--- a/Sources/Internal/GrpcClient.swift
+++ b/Sources/Internal/GrpcClient.swift
@@ -25,7 +25,7 @@ import OSLog
 import SwiftProtobuf
 
 @available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
-public typealias FirebaseDataConnectAsyncClient =
+typealias FirebaseDataConnectAsyncClient =
   Google_Firebase_Dataconnect_V1beta_ConnectorServiceAsyncClient
 
 @available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)

--- a/Sources/MutationRef.swift
+++ b/Sources/MutationRef.swift
@@ -15,11 +15,11 @@
 import Foundation
 
 @available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
-public struct MutationRequest<Variable: OperationVariable>: OperationRequest {
-  public var operationName: String
-  public var variables: Variable?
+struct MutationRequest<Variable: OperationVariable>: OperationRequest {
+  private(set) var operationName: String
+  private(set) var variables: Variable?
 
-  public init(operationName: String, variables: Variable? = nil) {
+  init(operationName: String, variables: Variable? = nil) {
     self.operationName = operationName
     self.variables = variables
   }
@@ -27,7 +27,7 @@ public struct MutationRequest<Variable: OperationVariable>: OperationRequest {
 
 @available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
 public class MutationRef<ResultData: Decodable, Variable: OperationVariable>: OperationRef {
-  public var request: any OperationRequest
+  private var request: any OperationRequest
 
   private var grpcClient: GrpcClient
 

--- a/Sources/QueryRef.swift
+++ b/Sources/QueryRef.swift
@@ -25,24 +25,24 @@ public enum ResultsPublisherType {
 }
 
 @available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
-public struct QueryRequest<Variable: OperationVariable>: OperationRequest, Hashable, Equatable {
-  public private(set) var operationName: String
-  public private(set) var variables: Variable?
+struct QueryRequest<Variable: OperationVariable>: OperationRequest, Hashable, Equatable {
+  private(set) var operationName: String
+  private(set) var variables: Variable?
 
-  public init(operationName: String, variables: Variable? = nil) {
+  init(operationName: String, variables: Variable? = nil) {
     self.operationName = operationName
     self.variables = variables
   }
 
   // Hashable and Equatable implementation
-  public func hash(into hasher: inout Hasher) {
+  func hash(into hasher: inout Hasher) {
     hasher.combine(operationName)
     if let variables {
       hasher.combine(variables)
     }
   }
 
-  public static func == (lhs: QueryRequest, rhs: QueryRequest) -> Bool {
+  static func == (lhs: QueryRequest, rhs: QueryRequest) -> Bool {
     guard lhs.operationName == rhs.operationName else {
       return false
     }
@@ -72,7 +72,7 @@ actor GenericQueryRef<ResultData: Decodable, Variable: OperationVariable>: Query
   private var resultsPublisher = PassthroughSubject<Result<ResultData, DataConnectError>,
     Never>()
 
-  var request: QueryRequest<Variable>
+  private var request: QueryRequest<Variable>
 
   private var grpcClient: GrpcClient
 
@@ -121,15 +121,6 @@ public protocol ObservableQueryRef: QueryRef {
   // last error received. if last fetch was successful this is cleared
   var lastError: DataConnectError? { get }
 }
-
-/*
- @available(iOS 15.0, macOS 11.0,  tvOS 15.0, watchOS 8.0, *)
- extension ObservableQueryRef {
-   public func subscribe() async throws -> AnyPublisher<Result<ResultDataType, DataConnectError>, Never> {
-     //return Empty<Result<ResultDataType, DataConnectError>, Never>()
-   }
- }
- */
 
 // QueryRef class used with ObservableObject protocol
 // data: Published variable that contains bindable results of the query.


### PR DESCRIPTION
Due to recent API changes, some protocols and structs don't need to be public. Adjusting their visiblity to package level (internal only)