### PR TITLE
Implement ref reuse to fix infinite loop issue

### DIFF
--- a/Sources/BaseOperationRef.swift
+++ b/Sources/BaseOperationRef.swift
@@ -24,7 +24,7 @@ public struct OperationResult<ResultData: Decodable> {
 public protocol OperationVariable: Encodable, Hashable, Equatable {}
 
 @available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
-protocol OperationRequest {
+protocol OperationRequest: Hashable, Equatable {
   associatedtype Variable: OperationVariable
   var operationName: String { get } // Name within Connector definition
   var variables: Variable? { get }

--- a/Sources/Internal/OperationsManager.swift
+++ b/Sources/Internal/OperationsManager.swift
@@ -18,6 +18,18 @@ import Foundation
 class OperationsManager {
   private var grpcClient: GrpcClient
 
+  private let queryRefAccessQ = DispatchQueue(
+    label: "firebase.dataconnect.queryRef.AccessQ",
+    autoreleaseFrequency: .workItem
+  )
+  private var queryRefs = [AnyHashable: any ObservableQueryRef]()
+
+  private let mutationRefAccessQ = DispatchQueue(
+    label: "firebase.dataconnect.mutRef.AccessQ",
+    autoreleaseFrequency: .workItem
+  )
+  private var mutationRefs = [AnyHashable: any OperationRef]()
+
   init(grpcClient: GrpcClient) {
     self.grpcClient = grpcClient
   }
@@ -28,34 +40,52 @@ class OperationsManager {
                                        .Type,
                                      publisher: ResultsPublisherType = .auto)
     -> any ObservableQueryRef {
-    switch publisher {
-    case .auto, .observableMacro:
-      if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
-        return QueryRefObservation<ResultDataType, VariableType>(
-          request: request,
-          dataType: resultType,
-          grpcClient: self.grpcClient
-        ) as (any ObservableQueryRef)
-      } else {
-        return QueryRefObservableObject<ResultDataType, VariableType>(
-          request: request,
-          dataType: resultType,
-          grpcClient: grpcClient
-        ) as (any ObservableQueryRef)
+    queryRefAccessQ.sync {
+      if let ref = queryRefs[AnyHashable(request)] {
+        return ref
       }
-    case .observableObject:
-      return QueryRefObservableObject<ResultDataType, VariableType>(
+
+      if publisher == .auto || publisher == .observableMacro {
+        if #available(iOS 17, macOS 14, tvOS 17, watchOS 10, *) {
+          let obsRef = QueryRefObservation<ResultDataType, VariableType>(
+            request: request,
+            dataType: resultType,
+            grpcClient: self.grpcClient
+          ) as (any ObservableQueryRef)
+          queryRefs[AnyHashable(request)] = obsRef
+          return obsRef
+        }
+      }
+
+      let refObsObject = QueryRefObservableObject<ResultDataType, VariableType>(
         request: request,
         dataType: resultType,
         grpcClient: grpcClient
       ) as (any ObservableQueryRef)
-    }
+      queryRefs[AnyHashable(request)] = refObsObject
+      return refObsObject
+    } // accessQ.sync
   }
 
   func mutationRef<ResultDataType: Decodable,
     VariableType: OperationVariable>(for request: MutationRequest<VariableType>,
                                      with resultType: ResultDataType
                                        .Type) -> MutationRef<ResultDataType, VariableType> {
-    return MutationRef(request: request, grpcClient: grpcClient)
-  }
+    mutationRefAccessQ.sync {
+      if let ref = mutationRefs[
+        AnyHashable(
+          request
+        )
+      ] as? MutationRef<ResultDataType, VariableType> {
+        return ref
+      }
+
+      let ref = MutationRef<ResultDataType, VariableType>(
+        request: request,
+        grpcClient: grpcClient
+      )
+      mutationRefs[AnyHashable(request)] = ref
+      return ref
+    }
+  } // accessQ.sync
 }

--- a/Tests/Unit/InstanceTests.swift
+++ b/Tests/Unit/InstanceTests.swift
@@ -80,4 +80,162 @@ class InstanceTests: XCTestCase {
     let isDifferent = dcOne !== dcTwo
     XCTAssertTrue(isDifferent)
   }
+
+  struct VariableTypeOne: OperationVariable {
+    var email: String
+    var handle: String
+    var someNumber: Int
+  }
+
+  // same query name, same variables, should return same instance
+  func testSameQueryRefInstance() throws {
+    let dc = DataConnect.dataConnect(connectorConfig: fakeConnectorConfigOne)
+
+    let queryName = "someQuery"
+    let variableOne = VariableTypeOne(email: "aa@g.com", handle: "aa@", someNumber: 12345)
+    let variableTwo = VariableTypeOne(email: "aa@g.com", handle: "aa@", someNumber: 12345)
+
+    let refOne = dc.query(
+      name: queryName,
+      variables: variableOne,
+      resultsDataType: Int.self,
+      publisher: .observableObject
+    ) as! QueryRefObservableObject<Int, VariableTypeOne>
+
+    let refTwo = dc.query(
+      name: queryName,
+      variables: variableTwo,
+      resultsDataType: Int.self,
+      publisher: .observableObject
+    ) as! QueryRefObservableObject<Int, VariableTypeOne>
+
+    let isSameInstance = refOne === refTwo
+    XCTAssertTrue(isSameInstance)
+  }
+
+  // same query name but different variable values (same variable type).
+  // should return different instances
+  func testQueryDifferentVariablesDifferentRefInstance() throws {
+    let dc = DataConnect.dataConnect(connectorConfig: fakeConnectorConfigOne)
+
+    let queryName = "someQuery"
+    let variableOne = VariableTypeOne(email: "aa1@g.com", handle: "aa@", someNumber: 12345)
+    let variableTwo = VariableTypeOne(email: "aa2@g.com", handle: "aa@", someNumber: 12345)
+
+    let refOne = dc.query(
+      name: queryName,
+      variables: variableOne,
+      resultsDataType: Int.self,
+      publisher: .observableObject
+    ) as! QueryRefObservableObject<Int, VariableTypeOne>
+
+    let refTwo = dc.query(
+      name: queryName,
+      variables: variableTwo,
+      resultsDataType: Int.self,
+      publisher: .observableObject
+    ) as! QueryRefObservableObject<Int, VariableTypeOne>
+
+    let isDifferentInstance = refOne !== refTwo
+    XCTAssertTrue(isDifferentInstance)
+  }
+
+  // different query names, same variables values
+  // should return different instances
+  func testDifferentQueryNamesSameVariables() throws {
+    let dc = DataConnect.dataConnect(connectorConfig: fakeConnectorConfigOne)
+
+    let queryNameOne = "someQueryOne"
+    let queryNameTwo = "someQueryTwo"
+    let variableOne = VariableTypeOne(email: "aa@g.com", handle: "aa@", someNumber: 12345)
+    let variableTwo = VariableTypeOne(email: "aa@g.com", handle: "aa@", someNumber: 12345)
+
+    let refOne = dc.query(
+      name: queryNameOne,
+      variables: variableOne,
+      resultsDataType: Int.self,
+      publisher: .observableObject
+    ) as! QueryRefObservableObject<Int, VariableTypeOne>
+
+    let refTwo = dc.query(
+      name: queryNameTwo,
+      variables: variableTwo,
+      resultsDataType: Int.self,
+      publisher: .observableObject
+    ) as! QueryRefObservableObject<Int, VariableTypeOne>
+
+    let isDifferentInstance = refOne !== refTwo
+    XCTAssertTrue(isDifferentInstance)
+  }
+
+  // same query name, same variables, should return same instance
+  func testSameMutationRefInstance() throws {
+    let dc = DataConnect.dataConnect(connectorConfig: fakeConnectorConfigOne)
+
+    let name = "someMutation"
+    let variableOne = VariableTypeOne(email: "aa@g.com", handle: "aa@", someNumber: 12345)
+    let variableTwo = VariableTypeOne(email: "aa@g.com", handle: "aa@", someNumber: 12345)
+
+    let refOne = dc.mutation(name: name, variables: variableOne, resultsDataType: Int.self)
+
+    let refTwo = dc.mutation(
+      name: name,
+      variables: variableTwo,
+      resultsDataType: Int.self
+    )
+
+    let isSameInstance = refOne === refTwo
+    XCTAssertTrue(isSameInstance)
+  }
+
+  // same mutation name but different variable values (same variable type).
+  // should return different instances
+  func testMutationDifferentVariablesDifferentRefInstance() throws {
+    let dc = DataConnect.dataConnect(connectorConfig: fakeConnectorConfigOne)
+
+    let name = "someQuery"
+    let variableOne = VariableTypeOne(email: "aa1@g.com", handle: "aa@", someNumber: 12345)
+    let variableTwo = VariableTypeOne(email: "aa2@g.com", handle: "aa@", someNumber: 12345)
+
+    let refOne = dc.mutation(
+      name: name,
+      variables: variableOne,
+      resultsDataType: Int.self
+    )
+
+    let refTwo = dc.mutation(
+      name: name,
+      variables: variableTwo,
+      resultsDataType: Int.self
+    )
+
+    let isDifferentInstance = refOne !== refTwo
+    XCTAssertTrue(isDifferentInstance)
+  }
+
+  // different mutation names, same variables values
+  // should return different instances
+  func testDifferentMutationNamesSameVariables() throws {
+    let dc = DataConnect.dataConnect(connectorConfig: fakeConnectorConfigOne)
+
+    let nameOne = "someNameOne"
+    let nameTwo = "someNameTwo"
+    let variableOne = VariableTypeOne(email: "aa@g.com", handle: "aa@", someNumber: 12345)
+    let variableTwo = VariableTypeOne(email: "aa@g.com", handle: "aa@", someNumber: 12345)
+
+    let refOne = dc.mutation(
+      name: nameOne,
+      variables: variableOne,
+      resultsDataType: Int.self
+    )
+
+    let refTwo = dc.mutation(
+      name: nameTwo,
+      variables: variableTwo,
+      resultsDataType: Int.self
+    )
+
+    let isDifferentInstance = refOne !== refTwo
+    XCTAssertTrue(isDifferentInstance)
+  }
 }


### PR DESCRIPTION
Reuse query and mutation refs keyed by operation name and variable values. 

Fixes the infinite loop issue that @peterfriese  found - https://github.com/firebase/data-connect-ios-sdk/pull/22