### PR TITLE
Update min macOS version to equivalent iOS 15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ import PackageDescription
 
 let package = Package(
   name: "FirebaseDataConnect",
-  platforms: [.iOS(.v15), .macOS(.v11), .tvOS(.v15), .watchOS(.v8)],
+  platforms: [.iOS(.v15), .macOS(.v12), .tvOS(.v15), .watchOS(.v8)],
   products: [
     .library(
       name: "FirebaseDataConnect",

--- a/Sources/BaseOperationRef.swift
+++ b/Sources/BaseOperationRef.swift
@@ -14,23 +14,23 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct OperationResult<ResultData: Decodable> {
   public var data: ResultData
 }
 
 // notional protocol that denotes a variable.
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public protocol OperationVariable: Encodable, Hashable, Equatable {}
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 protocol OperationRequest: Hashable, Equatable {
   associatedtype Variable: OperationVariable
   var operationName: String { get } // Name within Connector definition
   var variables: Variable? { get }
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public protocol OperationRef {
   associatedtype ResultData: Decodable
 

--- a/Sources/CodecHelper.swift
+++ b/Sources/CodecHelper.swift
@@ -22,7 +22,7 @@ import Foundation
  It is only for internal use by Data Connect generated code.
 
  */
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public class CodecHelper<K: CodingKey> {
   // MARK: Encoding
 

--- a/Sources/ConnectorConfig.swift
+++ b/Sources/ConnectorConfig.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct ConnectorConfig: Hashable, Equatable {
   public private(set) var serviceId: String
   public private(set) var location: String

--- a/Sources/DataConnect.swift
+++ b/Sources/DataConnect.swift
@@ -18,7 +18,7 @@ import FirebaseAppCheck
 import FirebaseAuth
 import FirebaseCore
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public class DataConnect {
   private var connectorConfig: ConnectorConfig
   private var app: FirebaseApp
@@ -132,7 +132,7 @@ public class DataConnect {
 }
 
 // This enum is public so the gen sdk can access it
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public enum CallerSDKType {
   case base // base sdk is directly used
   case generated // generated sdk is calling the base
@@ -142,7 +142,7 @@ public enum CallerSDKType {
 
 // Support for creating or reusing DataConnect instances.
 // Instances are keyed by ConnectorConfig and FirebaseApp (projectID)
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct InstanceKey: Hashable, Equatable {
   let config: ConnectorConfig
   let app: FirebaseApp
@@ -159,7 +159,7 @@ private struct InstanceKey: Hashable, Equatable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private class InstanceStore {
   let accessQ = DispatchQueue(
     label: "firebase.dataconnect.instanceQ",

--- a/Sources/DataConnectError.swift
+++ b/Sources/DataConnectError.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public enum DataConnectError: Error {
   // no firebase app specified. configure not complete
   case appNotConfigured

--- a/Sources/DataConnectSettings.swift
+++ b/Sources/DataConnectSettings.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct DataConnectSettings: Hashable, Equatable {
   public private(set) var host: String
   public private(set) var port: Int

--- a/Sources/Internal/CodableHelpers.swift
+++ b/Sources/Internal/CodableHelpers.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 protocol CodableConverter {
   associatedtype E: Encodable
   associatedtype D: Decodable
@@ -23,7 +23,7 @@ protocol CodableConverter {
   func decode(input: D) throws -> E
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class Int64CodableConverter: CodableConverter {
   func encode(input: Int64?) throws -> String? {
     guard let input else {
@@ -46,7 +46,7 @@ class Int64CodableConverter: CodableConverter {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class UUIDCodableConverter: CodableConverter {
   func encode(input: UUID?) throws -> String? {
     guard let input else {

--- a/Sources/Internal/CodableTimestamp.swift
+++ b/Sources/Internal/CodableTimestamp.swift
@@ -42,7 +42,7 @@ private enum TimestampKeys: String, CodingKey {
  * Note: this is implemented manually here because the Swift compiler can't synthesize these methods
  * when declaring an extension to conform to Codable.
  */
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension CodableTimestamp {
   public init(from decoder: any Swift.Decoder) throws {
     let container = try decoder.singleValueContainer()
@@ -75,7 +75,7 @@ extension CodableTimestamp {
 }
 
 /** Extends Timestamp to conform to Codable. */
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension Timestamp: CodableTimestamp {}
 
 class CodableTimestampHelper {

--- a/Sources/Internal/Codec.swift
+++ b/Sources/Internal/Codec.swift
@@ -16,13 +16,13 @@ import Foundation
 
 import SwiftProtobuf
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 typealias FirebaseDataConnectExecuteMutationRequest =
   Google_Firebase_Dataconnect_V1beta_ExecuteMutationRequest
 typealias FirebaseDataConnectExecuteQueryRequest =
   Google_Firebase_Dataconnect_V1beta_ExecuteQueryRequest
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class Codec {
   // Encode Codable to Protos
   func encode(args: any Encodable) throws -> Google_Protobuf_Struct {

--- a/Sources/Internal/Component.swift
+++ b/Sources/Internal/Component.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// Class for registration with the Firebase component system, including userAgent functionality.
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @objc(FIRDataConnectComponent) class DataConnectComponent: NSObject {
   @objc class func sdkVersion() -> String {
     return Version.sdkVersion

--- a/Sources/Internal/FirebaseLogger/DataConnectLogger.swift
+++ b/Sources/Internal/FirebaseLogger/DataConnectLogger.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension FirebaseLogger {
   static let dataConnect = FirebaseLogger(category: "data_connect")
 }

--- a/Sources/Internal/FirebaseLogger/FirebaseLogger.swift
+++ b/Sources/Internal/FirebaseLogger/FirebaseLogger.swift
@@ -15,7 +15,7 @@
 import Foundation
 import OSLog
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public class FirebaseLogger {
   let subsystem: String = "com.google.firebase"
 

--- a/Sources/Internal/GrpcClient.swift
+++ b/Sources/Internal/GrpcClient.swift
@@ -24,11 +24,11 @@ import NIOPosix
 import OSLog
 import SwiftProtobuf
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 typealias FirebaseDataConnectAsyncClient =
   Google_Firebase_Dataconnect_V1beta_ConnectorServiceAsyncClient
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 actor GrpcClient: CustomStringConvertible {
   nonisolated let description: String
 

--- a/Sources/Internal/OperationsManager.swift
+++ b/Sources/Internal/OperationsManager.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class OperationsManager {
   private var grpcClient: GrpcClient
 

--- a/Sources/Internal/Version.swift
+++ b/Sources/Internal/Version.swift
@@ -16,7 +16,7 @@ import Foundation
 
 import GoogleUtilities_Environment
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct Version {
   static let sdkVersion = "11.3.0-beta"
 

--- a/Sources/MutationRef.swift
+++ b/Sources/MutationRef.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct MutationRequest<Variable: OperationVariable>: OperationRequest {
   private(set) var operationName: String
   private(set) var variables: Variable?
@@ -25,7 +25,7 @@ struct MutationRequest<Variable: OperationVariable>: OperationRequest {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public class MutationRef<ResultData: Decodable, Variable: OperationVariable>: OperationRef {
   private var request: any OperationRequest
 

--- a/Sources/OptionalVarWrapper.swift
+++ b/Sources/OptionalVarWrapper.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @propertyWrapper
 public struct OptionalVariable<Value> where Value: Encodable {
   public private(set) var isSet = false
@@ -44,7 +44,7 @@ public struct OptionalVariable<Value> where Value: Encodable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension OptionalVariable: Encodable {
   public func encode(to encoder: Encoder) throws {
     if isSet {

--- a/Sources/QueryRef.swift
+++ b/Sources/QueryRef.swift
@@ -17,14 +17,14 @@ import Foundation
 import Combine
 import Observation
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public enum ResultsPublisherType {
   case auto // automatically determine ObservableQueryRef
   case observableObject // pre-iOS 17 ObservableObject
   case observableMacro // iOS 17+ Observation framework
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct QueryRequest<Variable: OperationVariable>: OperationRequest, Hashable, Equatable {
   private(set) var operationName: String
   private(set) var variables: Variable?
@@ -61,13 +61,13 @@ struct QueryRequest<Variable: OperationVariable>: OperationRequest, Hashable, Eq
   }
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public protocol QueryRef: OperationRef {
   // This call starts query execution and publishes data
   func subscribe() async throws -> AnyPublisher<Result<ResultData, DataConnectError>, Never>
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 actor GenericQueryRef<ResultData: Decodable, Variable: OperationVariable>: QueryRef {
   private var resultsPublisher = PassthroughSubject<Result<ResultData, DataConnectError>,
     Never>()
@@ -113,7 +113,7 @@ actor GenericQueryRef<ResultData: Decodable, Variable: OperationVariable>: Query
   }
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public protocol ObservableQueryRef: QueryRef {
   // results of fetch.
   var data: ResultData? { get }
@@ -126,7 +126,7 @@ public protocol ObservableQueryRef: QueryRef {
 // data: Published variable that contains bindable results of the query.
 // lastError: Published variable that contains DataConnectError if last fetch had error.
 //            If last fetch was successful, this variable is cleared
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public class QueryRefObservableObject<
   ResultData: Decodable,
   Variable: OperationVariable

--- a/Sources/Scalars/AnyValue.swift
+++ b/Sources/Scalars/AnyValue.swift
@@ -16,7 +16,7 @@ import Foundation
 
 /// AnyValue represents the Any graphql scalar, which represents Codable data -  scalar data (Int,
 /// Double, String, Bool,...) or a JSON object
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct AnyValue {
   public private(set) var value: Data
 
@@ -36,7 +36,7 @@ public struct AnyValue {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension AnyValue: Codable {
   public init(from decoder: any Decoder) throws {
     let singleValueContainer = try decoder.singleValueContainer()
@@ -49,14 +49,14 @@ extension AnyValue: Codable {
   }
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension AnyValue: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     return lhs.value == rhs.value
   }
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension AnyValue: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(value)

--- a/Sources/Scalars/LocalDate.swift
+++ b/Sources/Scalars/LocalDate.swift
@@ -19,7 +19,7 @@ import Foundation
 
  Essentially represents: https://the-guild.dev/graphql/scalars/docs/scalars/local-date
  */
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public struct LocalDate: Codable, Equatable, Comparable, CustomStringConvertible {
   private var calendar = Calendar(identifier: .gregorian)
   private var dateFormatter = DateFormatter()
@@ -76,7 +76,7 @@ public struct LocalDate: Codable, Equatable, Comparable, CustomStringConvertible
   }
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public extension LocalDate {
   init(from decoder: any Decoder) throws {
     let container = try decoder.singleValueContainer()
@@ -96,7 +96,7 @@ public extension LocalDate {
 
 // MARK: Equatable, Comparable
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public extension LocalDate {
   static func < (lhs: LocalDate, rhs: LocalDate) -> Bool {
     return lhs.date < rhs.date
@@ -109,7 +109,7 @@ public extension LocalDate {
 
 // MARK: Hashable
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension LocalDate: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(date)

--- a/Tests/Integration/AnyScalarTests.swift
+++ b/Tests/Integration/AnyScalarTests.swift
@@ -17,7 +17,7 @@ import XCTest
 import FirebaseCore
 @testable import FirebaseDataConnect
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class AnyScalarTests: IntegrationTestBase {
   override func setUp(completion: @escaping ((any Error)?) -> Void) {
     Task {

--- a/Tests/Integration/ConfigSetup.swift
+++ b/Tests/Integration/ConfigSetup.swift
@@ -17,12 +17,12 @@ import Foundation
 import FirebaseCore
 import FirebaseDataConnect
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 enum KitchenSinkError: Error {
   case configureFailed
 }
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 actor ProjectConfigurator {
   static let shared = ProjectConfigurator()
 

--- a/Tests/Integration/IntegrationTestBase.swift
+++ b/Tests/Integration/IntegrationTestBase.swift
@@ -18,7 +18,7 @@ import FirebaseCore
 @testable import FirebaseDataConnect
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class IntegrationTestBase: XCTestCase {
   static var defaultApp: FirebaseApp?
 

--- a/Tests/Integration/IntegrationTests.swift
+++ b/Tests/Integration/IntegrationTests.swift
@@ -17,7 +17,7 @@ import XCTest
 import FirebaseCore
 @testable import FirebaseDataConnect
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class IntegrationTests: IntegrationTestBase {
   override func setUp(completion: @escaping ((any Error)?) -> Void) {
     Task {

--- a/Tests/Unit/CodecHelperTests.swift
+++ b/Tests/Unit/CodecHelperTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 @testable import FirebaseDataConnect
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class CodecHelperTests: XCTestCase {
   override func setUpWithError() throws {}
 

--- a/Tests/Unit/HeaderTests.swift
+++ b/Tests/Unit/HeaderTests.swift
@@ -19,7 +19,7 @@ import GRPC
 
 import XCTest
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class HeaderTests: XCTestCase {
   static var defaultApp: FirebaseApp?
 

--- a/Tests/Unit/InstanceTests.swift
+++ b/Tests/Unit/InstanceTests.swift
@@ -17,7 +17,7 @@ import FirebaseCore
 import Foundation
 import XCTest
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 class InstanceTests: XCTestCase {
   static var defaultApp: FirebaseApp?
   static var appTwo: FirebaseApp?

--- a/Tests/Unit/LocalDateTests.swift
+++ b/Tests/Unit/LocalDateTests.swift
@@ -17,7 +17,7 @@ import XCTest
 @testable import FirebaseDataConnect
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class LocalDateTests: XCTestCase {
   override func setUpWithError() throws {}
 

--- a/Tests/Unit/TimestampCodableTests.swift
+++ b/Tests/Unit/TimestampCodableTests.swift
@@ -18,7 +18,7 @@ import FirebaseCore
 @testable import FirebaseDataConnect
 import Foundation
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class TimestampTests: XCTestCase {
   override func setUpWithError() throws {}
 

--- a/Tests/Unit/UserAgentTests.swift
+++ b/Tests/Unit/UserAgentTests.swift
@@ -18,7 +18,7 @@ import XCTest
 import FirebaseCore
 @testable import FirebaseDataConnect
 
-@available(iOS 15.0, macOS 11.0, tvOS 15.0, watchOS 8.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class UserAgentTests: XCTestCase {
   static var options: FirebaseOptions = {
     let options = FirebaseOptions(googleAppID: "0:0000000000000:ios:0000000000000000",


### PR DESCRIPTION
The macOS release equivalent to iOS 15 is macOS 12. Updating version so we have option to use CodableWithConfiguration across platforms. 