### PR TITLE
Throw error if partial errors are detected

### DIFF
--- a/Sources/DataConnectError.swift
+++ b/Sources/DataConnectError.swift
@@ -37,5 +37,4 @@ public enum DataConnectError: Error {
 
   /// generic operation execution error
   case operationExecutionFailed
-
 }

--- a/Sources/DataConnectError.swift
+++ b/Sources/DataConnectError.swift
@@ -34,4 +34,8 @@ public enum DataConnectError: Error {
 
   /// timestamp components specified to initialize Timestamp are invalid
   case invalidTimestampFormat
+
+  /// generic operation execution error
+  case operationExecutionFailed
+
 }

--- a/Sources/DataConnectError.swift
+++ b/Sources/DataConnectError.swift
@@ -36,5 +36,5 @@ public enum DataConnectError: Error {
   case invalidTimestampFormat
 
   /// generic operation execution error
-  case operationExecutionFailed
+  case operationExecutionFailed(messages: String?)
 }

--- a/Sources/Internal/GrpcClient.swift
+++ b/Sources/Internal/GrpcClient.swift
@@ -148,7 +148,12 @@ actor GrpcClient: CustomStringConvertible {
       let resultsString = try results.jsonString()
       DataConnectLogger
         .debug("executeQuery() receives response: \(resultsString, privacy: .private).")
+
       // Not doing error decoding here
+      guard results.errors.isEmpty else {
+        throw DataConnectError.operationExecutionFailed
+      }
+
       if let decodedResults = try codec.decode(result: results.data, asType: resultType) {
         return OperationResult(data: decodedResults)
       } else {
@@ -191,6 +196,11 @@ actor GrpcClient: CustomStringConvertible {
       let resultsString = try results.jsonString()
       DataConnectLogger
         .debug("executeMutation() receives response: \(resultsString, privacy: .private).")
+
+      guard results.errors.isEmpty else {
+        throw DataConnectError.operationExecutionFailed
+      }
+
       if let decodedResults = try codec.decode(result: results.data, asType: resultType) {
         return OperationResult(data: decodedResults)
       } else {


### PR DESCRIPTION
iOS SDK should throw if partial errors are detected in an operation execution response. 