### PR TITLE
Update package version and dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -79,7 +79,7 @@ func firebaseDependency() -> Package.Dependency {
     return .package(url: firebaseURL, branch: "main")
   }
 
-  return .package(url: firebaseURL, exact: "11.5.0")
+  return .package(url: firebaseURL, from: "11.5.0")
 }
 
 func integrationTestPath() -> String? {

--- a/Sources/Internal/Version.swift
+++ b/Sources/Internal/Version.swift
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import GoogleUtilities_Environment
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct Version {
-  static let sdkVersion = "11.3.0-beta"
+  static let sdkVersion = "11.6.0-beta"
 
   // returns value of form gl-PLATFORM_NAME/PLATFORM_VERSION
   static func platformVersionHeader() -> String {


### PR DESCRIPTION
- Updates package version to - 11.6.0-beta
- Updates minimum dependency for Firebase iOS SDK flag to `from` instead of `exact` now that we have CI tests functioning. 

