### PR TITLE
Change Firebase SDK dependency requirement 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -79,7 +79,7 @@ func firebaseDependency() -> Package.Dependency {
     return .package(url: firebaseURL, branch: "main")
   }
 
-  return .package(url: firebaseURL, exact: "11.5.0")
+  return .package(url: firebaseURL, from: "11.5.0")
 }
 
 func integrationTestPath() -> String? {


### PR DESCRIPTION
Change dependency to 'minimum' version instead of 'exact' version. This allows clients to still use latest versions of Firebase iOS SDK. 