### PR TITLE
Include server error messages in DataConnectOperationError 

### DIFF
--- a/Sources/DataConnectError.swift
+++ b/Sources/DataConnectError.swift
@@ -217,6 +217,15 @@ public struct DataConnectOperationError: DataConnectError {
     -> DataConnectOperationError {
     return DataConnectOperationError(message: message, cause: cause, response: response)
   }
+
+  // include the underlying errors from errorInfo list in the description
+  public var debugDescription: String {
+    let errorInfos = response?.errors.compactMap {
+      $0.message
+    }.joined(separator: "\n")
+
+    return "{\(Self.self), \nerrors: \(errorInfos) \noriginatingError: \(String(describing: underlyingError))}"
+  }
 }
 
 /// Contains the data and errors sent to us from the backend in its response.


### PR DESCRIPTION
We were not including the error info list messages in the debug description for DataConnectOperationError since we were using the inherited implemented. As a result, when the error was printed, a developer wouldn't see the error messages. 

This PR fixes - https://github.com/firebase/firebase-ios-sdk/issues/14945