### PR TITLE
Upgrade Firebase dependency to include 12.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -79,7 +79,7 @@ func firebaseDependency() -> Package.Dependency {
     return .package(url: firebaseURL, branch: "main")
   }
 
-  return .package(url: firebaseURL, from: "12.0.0")
+  return .package(url: firebaseURL, "11.5.0" ..< "13.0.0")
 }
 
 func integrationTestPath() -> String? {


### PR DESCRIPTION
Update the dependency Firebase Core SDK dependency to minimum 12.0.0.

Fixes: https://github.com/firebase/firebase-ios-sdk/issues/15139