### PR TITLE
Implement mutation execution on the stream.

### DIFF
--- a/Sources/Internal/GrpcClient.swift
+++ b/Sources/Internal/GrpcClient.swift
@@ -158,11 +158,15 @@ actor DataConnectGrpcClient: GrpcClient, CustomStringConvertible {
   >(request: QueryRequest<VariableType>,
     resultType: ResultType.Type)
     async throws -> ServerResponse {
-    do {
-      return try await streamingClient.executeQuery(request: request, resultType: resultType)
-    } catch {
-      // TODO: Distinguish network errors from stream errors.
-      DataConnectLogger.error("Error executing on stream mode, falling back to unary mode ")
+    if await streamingClient.hasActiveSubscriptions() {
+      do {
+        return try await streamingClient.executeQuery(request: request, resultType: resultType)
+      } catch {
+        // TODO: Distinguish network errors from stream errors.
+        DataConnectLogger.error("Error executing queries on stream mode, falling back to unary mode")
+        return try await unaryClient.executeQuery(request: request, resultType: resultType)
+      }
+    } else {
       return try await unaryClient.executeQuery(request: request, resultType: resultType)
     }
   }
@@ -174,7 +178,13 @@ actor DataConnectGrpcClient: GrpcClient, CustomStringConvertible {
     resultType: ResultType.Type)
     async throws -> OperationResult<ResultType> {
     if await streamingClient.hasActiveSubscriptions() {
-      return try await streamingClient.executeMutation(request: request, resultType: resultType)
+      do {
+        return try await streamingClient.executeMutation(request: request, resultType: resultType)
+      } catch {
+        // TODO: Distinguish network errors from stream errors.
+        DataConnectLogger.error("Error executing mutations on stream mode, falling back to unary mode")
+        return try await unaryClient.executeMutation(request: request, resultType: resultType)
+      }
     } else {
       return try await unaryClient.executeMutation(request: request, resultType: resultType)
     }

--- a/Sources/Internal/GrpcClient.swift
+++ b/Sources/Internal/GrpcClient.swift
@@ -163,7 +163,8 @@ actor DataConnectGrpcClient: GrpcClient, CustomStringConvertible {
         return try await streamingClient.executeQuery(request: request, resultType: resultType)
       } catch {
         // TODO: Distinguish network errors from stream errors.
-        DataConnectLogger.error("Error executing queries on stream mode, falling back to unary mode")
+        DataConnectLogger
+          .error("Error executing queries on stream mode, falling back to unary mode")
         return try await unaryClient.executeQuery(request: request, resultType: resultType)
       }
     } else {
@@ -182,7 +183,8 @@ actor DataConnectGrpcClient: GrpcClient, CustomStringConvertible {
         return try await streamingClient.executeMutation(request: request, resultType: resultType)
       } catch {
         // TODO: Distinguish network errors from stream errors.
-        DataConnectLogger.error("Error executing mutations on stream mode, falling back to unary mode")
+        DataConnectLogger
+          .error("Error executing mutations on stream mode, falling back to unary mode")
         return try await unaryClient.executeMutation(request: request, resultType: resultType)
       }
     } else {

--- a/Sources/Internal/GrpcClient.swift
+++ b/Sources/Internal/GrpcClient.swift
@@ -164,12 +164,10 @@ actor DataConnectGrpcClient: GrpcClient, CustomStringConvertible {
       } catch {
         // TODO: Distinguish network errors from stream errors.
         DataConnectLogger
-          .error("Error executing queries on stream mode, falling back to unary mode")
-        return try await unaryClient.executeQuery(request: request, resultType: resultType)
+          .error("Error executing queries with streaming gRPC, falling back to non-streaming.")
       }
-    } else {
-      return try await unaryClient.executeQuery(request: request, resultType: resultType)
     }
+    return try await unaryClient.executeQuery(request: request, resultType: resultType)
   }
 
   func executeMutation<
@@ -184,12 +182,10 @@ actor DataConnectGrpcClient: GrpcClient, CustomStringConvertible {
       } catch {
         // TODO: Distinguish network errors from stream errors.
         DataConnectLogger
-          .error("Error executing mutations on stream mode, falling back to unary mode")
-        return try await unaryClient.executeMutation(request: request, resultType: resultType)
+          .error("Error executing mutations with streaming gRPC, falling back to non-streaming.")
       }
-    } else {
-      return try await unaryClient.executeMutation(request: request, resultType: resultType)
     }
+    return try await unaryClient.executeMutation(request: request, resultType: resultType)
   }
 
   func subscribe<

--- a/Sources/Internal/GrpcClient.swift
+++ b/Sources/Internal/GrpcClient.swift
@@ -173,8 +173,11 @@ actor DataConnectGrpcClient: GrpcClient, CustomStringConvertible {
   >(request: MutationRequest<VariableType>,
     resultType: ResultType.Type)
     async throws -> OperationResult<ResultType> {
-    // TODO: Support executing mutations on the stream.
-    return try await unaryClient.executeMutation(request: request, resultType: resultType)
+    if await streamingClient.hasActiveSubscriptions() {
+      return try await streamingClient.executeMutation(request: request, resultType: resultType)
+    } else {
+      return try await unaryClient.executeMutation(request: request, resultType: resultType)
+    }
   }
 
   func subscribe<

--- a/Sources/Internal/OperationUtils.swift
+++ b/Sources/Internal/OperationUtils.swift
@@ -1,0 +1,40 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+enum OperationUtils {
+  static func computeRequestId<Variable: OperationVariable>(operationName: String,
+                                                            variables: Variable?) -> String {
+    var keyIdData = Data()
+    if let nameData = operationName.data(using: .utf8) {
+      keyIdData.append(nameData)
+    }
+
+    if let variables {
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = .sortedKeys
+      do {
+        let jsonData = try encoder.encode(variables)
+        keyIdData.append(jsonData)
+      } catch {
+        DataConnectLogger
+          .warning("Error encoding variables to compute request identifier: \(error)")
+      }
+    }
+
+    return keyIdData.sha256String
+  }
+}

--- a/Sources/Internal/ProtoCodec.swift
+++ b/Sources/Internal/ProtoCodec.swift
@@ -42,9 +42,8 @@ class ProtoCodec {
   }
 
   // Generic ExecuteRequest object used for different stream messages - subscribe, execute, ...
-  func createStreamExecuteRequest<VariableType: OperationVariable>(request: QueryRequest<
-    VariableType
-  >) throws -> Google_Firebase_Dataconnect_V1_ExecuteRequest {
+  func createStreamExecuteRequest<Req: OperationRequest>(request: Req) throws
+    -> Google_Firebase_Dataconnect_V1_ExecuteRequest {
     var protoReq = Google_Firebase_Dataconnect_V1_ExecuteRequest()
     protoReq.operationName = request.operationName
     if let variables = request.variables {

--- a/Sources/Internal/StreamingGrpcClient.swift
+++ b/Sources/Internal/StreamingGrpcClient.swift
@@ -80,7 +80,10 @@ actor StreamingGrpcClient: GrpcClient {
   }
 
   func connectStream() async {
-    if streamingCall != nil {
+    guard streamingCall == nil else {
+      DataConnectLogger.debug(
+        "gRPC stream already set up. Ignoring connectStream() call."
+      )
       return
     }
 

--- a/Sources/Internal/StreamingGrpcClient.swift
+++ b/Sources/Internal/StreamingGrpcClient.swift
@@ -94,7 +94,7 @@ actor StreamingGrpcClient: GrpcClient {
       do {
         guard let streamingClient else {
           DataConnectLogger.error(
-            "When calling connectStream(), grpc client has not been configured."
+            "When calling connectStream(), gRPC client has not been configured."
           )
           return
         }
@@ -163,7 +163,7 @@ actor StreamingGrpcClient: GrpcClient {
     -> ServerResponse {
     guard let streamingCall else {
       DataConnectLogger.error(
-        "When calling executeOperationStream(), grpc client has not been configured."
+        "When calling executeOperation(), gRPC client has not been configured."
       )
       throw DataConnectInternalError.internalError(message: "Streaming call not configured")
     }
@@ -205,7 +205,7 @@ actor StreamingGrpcClient: GrpcClient {
 
     guard let streamingCall else {
       DataConnectLogger.error(
-        "When calling subscribe(), grpc streaming client has not been configured."
+        "When calling subscribe(), gRPC streaming client has not been configured."
       )
       throw DataConnectInitError.appNotConfigured(message: "GRPC Streaming failed to setup")
     }

--- a/Sources/Internal/StreamingGrpcClient.swift
+++ b/Sources/Internal/StreamingGrpcClient.swift
@@ -182,8 +182,44 @@ actor StreamingGrpcClient: GrpcClient {
   >(request: MutationRequest<VariableType>,
     resultType: ResultType.Type)
     async throws -> OperationResult<ResultType> {
-    throw DataConnectInternalError
-      .internalError(message: "Mutation not supported in StreamingGrpcClient")
+    guard let streamingCall else {
+      DataConnectLogger.error(
+        "When calling executeMutationStream(), grpc client has not been configured."
+      )
+      throw DataConnectInternalError.internalError(message: "Streaming call not configured")
+    }
+
+    do {
+      var fdcRequest = request
+
+      let seqRequestId = RequestIdentifier(
+        operationId: fdcRequest.requestId,
+        sequenceNumber: nextRequestIdSequence
+      )
+
+      let protoCodec = ProtoCodec()
+      var streamRequest = FirebaseDataConnectStreamRequest()
+      streamRequest.requestID = "\(seqRequestId)"
+      streamRequest.execute = try protoCodec.createStreamExecuteRequest(request: fdcRequest)
+
+      DataConnectLogger
+        .debug(
+          "Making streaming call with request \(streamRequest.requestID), \(streamRequest.name), \(streamRequest.execute.operationName)"
+        )
+
+      async let response = subManager.waitForResponse(for: seqRequestId)
+      try DataConnectLogger.debug("Sending streaming request \(streamRequest.jsonString())")
+      try await streamingCall.requestStream.send(streamRequest)
+      DataConnectLogger.debug("Done sending request")
+
+      let serverResponse = try await response
+      let jsonDecoder = JSONDecoder()
+      let decodedResults = try jsonDecoder.decode(ResultType.self, from: serverResponse.data)
+      return OperationResult(data: decodedResults, source: .server)
+    } catch {
+      DataConnectLogger.error("Error sending request to the server: \(error)")
+      throw error
+    }
   }
 
   func subscribe<
@@ -222,6 +258,10 @@ actor StreamingGrpcClient: GrpcClient {
     }
 
     return stream
+  }
+
+  func hasActiveSubscriptions() async -> Bool {
+    await subManager.hasAnySubscription()
   }
 
   func createCallOptions() async -> CallOptions {
@@ -298,6 +338,10 @@ private actor StreamSubscriptionManager {
 
   func hasSubscription(for operationId: String) -> Bool {
     operationSubs[operationId] != nil
+  }
+
+  func hasAnySubscription() -> Bool {
+    !operationSubs.isEmpty
   }
 
   func removeSubscription(for requestID: RequestIdentifier) {

--- a/Sources/Internal/StreamingGrpcClient.swift
+++ b/Sources/Internal/StreamingGrpcClient.swift
@@ -139,25 +139,45 @@ actor StreamingGrpcClient: GrpcClient {
   >(request: QueryRequest<VariableType>,
     resultType: ResultType.Type)
     async throws -> ServerResponse {
+    var fdcRequest = request
+    let requestId = fdcRequest.requestId
+    return try await executeOperation(request: fdcRequest, requestId: requestId)
+  }
+
+  func executeMutation<
+    ResultType: Decodable,
+    VariableType: OperationVariable
+  >(request: MutationRequest<VariableType>,
+    resultType: ResultType.Type)
+    async throws -> OperationResult<ResultType> {
+    var fdcRequest = request
+    let requestId = fdcRequest.requestId
+    let serverResponse = try await executeOperation(request: fdcRequest, requestId: requestId)
+    let jsonDecoder = JSONDecoder()
+    let decodedResults = try jsonDecoder.decode(ResultType.self, from: serverResponse.data)
+    return OperationResult(data: decodedResults, source: .server)
+  }
+
+  private func executeOperation<Req: OperationRequest>(request: Req,
+                                                       requestId: String) async throws
+    -> ServerResponse {
     guard let streamingCall else {
       DataConnectLogger.error(
-        "When calling executeQueryStream(), grpc client has not been configured."
+        "When calling executeOperationStream(), grpc client has not been configured."
       )
       throw DataConnectInternalError.internalError(message: "Streaming call not configured")
     }
 
     do {
-      var fdcRequest = request
-
       let seqRequestId = RequestIdentifier(
-        operationId: fdcRequest.requestId,
+        operationId: requestId,
         sequenceNumber: nextRequestIdSequence
       )
 
       let protoCodec = ProtoCodec()
       var streamRequest = FirebaseDataConnectStreamRequest()
       streamRequest.requestID = "\(seqRequestId)"
-      streamRequest.execute = try protoCodec.createStreamExecuteRequest(request: fdcRequest)
+      streamRequest.execute = try protoCodec.createStreamExecuteRequest(request: request)
 
       DataConnectLogger
         .debug(
@@ -170,52 +190,6 @@ actor StreamingGrpcClient: GrpcClient {
       DataConnectLogger.debug("Done sending request")
 
       return try await response
-    } catch {
-      DataConnectLogger.error("Error sending request to the server: \(error)")
-      throw error
-    }
-  }
-
-  func executeMutation<
-    ResultType: Decodable,
-    VariableType: OperationVariable
-  >(request: MutationRequest<VariableType>,
-    resultType: ResultType.Type)
-    async throws -> OperationResult<ResultType> {
-    guard let streamingCall else {
-      DataConnectLogger.error(
-        "When calling executeMutationStream(), grpc client has not been configured."
-      )
-      throw DataConnectInternalError.internalError(message: "Streaming call not configured")
-    }
-
-    do {
-      var fdcRequest = request
-
-      let seqRequestId = RequestIdentifier(
-        operationId: fdcRequest.requestId,
-        sequenceNumber: nextRequestIdSequence
-      )
-
-      let protoCodec = ProtoCodec()
-      var streamRequest = FirebaseDataConnectStreamRequest()
-      streamRequest.requestID = "\(seqRequestId)"
-      streamRequest.execute = try protoCodec.createStreamExecuteRequest(request: fdcRequest)
-
-      DataConnectLogger
-        .debug(
-          "Making streaming call with request \(streamRequest.requestID), \(streamRequest.name), \(streamRequest.execute.operationName)"
-        )
-
-      async let response = subManager.waitForResponse(for: seqRequestId)
-      try DataConnectLogger.debug("Sending streaming request \(streamRequest.jsonString())")
-      try await streamingCall.requestStream.send(streamRequest)
-      DataConnectLogger.debug("Done sending request")
-
-      let serverResponse = try await response
-      let jsonDecoder = JSONDecoder()
-      let decodedResults = try jsonDecoder.decode(ResultType.self, from: serverResponse.data)
-      return OperationResult(data: decodedResults, source: .server)
     } catch {
       DataConnectLogger.error("Error sending request to the server: \(error)")
       throw error

--- a/Sources/Internal/StreamingGrpcClient.swift
+++ b/Sources/Internal/StreamingGrpcClient.swift
@@ -33,6 +33,7 @@ actor StreamingGrpcClient: GrpcClient {
 
   private var streamingCall: FirebaseDataConnectStreamingCall?
   private var subManager = StreamSubscriptionManager()
+  private var connectionTask: Task<Void, Never>?
 
   private var requestIdSequence: UInt64 = 0
 
@@ -76,61 +77,60 @@ actor StreamingGrpcClient: GrpcClient {
     self.callerSDKType = callerSDKType
     self.googRequestHeaderValue = googRequestHeaderValue
     self.googApiClientHeaderValue = googApiClientHeaderValue
-
-    Task {
-      // TODO: Handle failures here.
-      await connectStream()
-    }
   }
 
   func connectStream() async {
-    do {
-      guard streamingCall == nil else {
-        DataConnectLogger.debug("connectStream() called multiple times, ignoring.")
-        return
-      }
-
-      guard let streamingClient else {
-        DataConnectLogger.error(
-          "When calling connectStream(), grpc client has not been configured."
-        )
-        return
-      }
-
-      let callOptions = await createCallOptions()
-      streamingCall = streamingClient.makeConnectCall(callOptions: callOptions)
-
-      guard let streamingCall else {
-        DataConnectLogger.error("Error: Failed to setup a streaming call")
-        return
-      }
-
-      requestIdSequence = 0 // reset sequence
-      let firstRequestId = RequestIdentifier(
-        operationId: UUID().uuidString,
-        sequenceNumber: nextRequestIdSequence
-      )
-      var firstRequest = FirebaseDataConnectStreamRequest()
-      firstRequest.requestID = firstRequestId.stringValue
-      firstRequest.name = connectorName
-      try await streamingCall.requestStream.send(firstRequest)
-      DataConnectLogger.debug("Created streaming call")
-
-      Task {
-        do {
-          for try await response in streamingCall.responseStream {
-            DataConnectLogger.debug("Received stream response from the server: \(response)")
-            await subManager.handleResponse(response)
-          }
-        } catch {
-          DataConnectLogger.error("Error in stream response \(error)")
-        }
-      }
-
-    } catch {
-      // TODO: Handle stream connect failure. Retries?
-      DataConnectLogger.error("Error setting up stream: \(error)")
+    if streamingCall != nil {
+      return
     }
+
+    if let existingTask = connectionTask {
+      _ = await existingTask.result
+      return
+    }
+
+    connectionTask = Task {
+      defer { connectionTask = nil }
+      do {
+        guard let streamingClient else {
+          DataConnectLogger.error(
+            "When calling connectStream(), grpc client has not been configured."
+          )
+          return
+        }
+
+        let callOptions = await createCallOptions()
+        let call = streamingClient.makeConnectCall(callOptions: callOptions)
+
+        requestIdSequence = 0 // reset sequence
+        let firstRequestId = RequestIdentifier(
+          operationId: UUID().uuidString,
+          sequenceNumber: nextRequestIdSequence
+        )
+        var firstRequest = FirebaseDataConnectStreamRequest()
+        firstRequest.requestID = firstRequestId.stringValue
+        firstRequest.name = connectorName
+        try await call.requestStream.send(firstRequest)
+        DataConnectLogger.debug("Created streaming call")
+
+        let subManager = self.subManager
+        Task {
+          do {
+            for try await response in call.responseStream {
+              DataConnectLogger.debug("Received stream response from the server: \(response)")
+              await subManager.handleResponse(response)
+            }
+          } catch {
+            DataConnectLogger.error("Error in stream response \(error)")
+          }
+        }
+
+        self.streamingCall = call
+      } catch {
+        DataConnectLogger.error("Error setting up stream: \(error)")
+      }
+    }
+    _ = await connectionTask?.result
   }
 
   func executeQuery<
@@ -227,6 +227,8 @@ actor StreamingGrpcClient: GrpcClient {
     VariableType: OperationVariable
   >(request: QueryRequest<VariableType>,
     resultType: ResultType.Type) async throws -> AsyncStream<ServerResponse> {
+    await connectStream()
+
     guard let streamingCall else {
       DataConnectLogger.error(
         "When calling subscribe(), grpc streaming client has not been configured."

--- a/Sources/MutationRef.swift
+++ b/Sources/MutationRef.swift
@@ -19,6 +19,28 @@ struct MutationRequest<Variable: OperationVariable>: OperationRequest {
   private(set) var operationName: String
   private(set) var variables: Variable?
 
+  // Computed requestId
+  lazy var requestId: String = {
+    var keyIdData = Data()
+    if let nameData = operationName.data(using: .utf8) {
+      keyIdData.append(nameData)
+    }
+
+    if let variables {
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = .sortedKeys
+      do {
+        let jsonData = try encoder.encode(variables)
+        keyIdData.append(jsonData)
+      } catch {
+        DataConnectLogger
+          .warning("Error encoding variables to compute request identifier: \(error)")
+      }
+    }
+
+    return keyIdData.sha256String
+  }()
+
   init(operationName: String, variables: Variable? = nil) {
     self.operationName = operationName
     self.variables = variables

--- a/Sources/MutationRef.swift
+++ b/Sources/MutationRef.swift
@@ -20,26 +20,8 @@ struct MutationRequest<Variable: OperationVariable>: OperationRequest {
   private(set) var variables: Variable?
 
   // Computed requestId
-  lazy var requestId: String = {
-    var keyIdData = Data()
-    if let nameData = operationName.data(using: .utf8) {
-      keyIdData.append(nameData)
-    }
-
-    if let variables {
-      let encoder = JSONEncoder()
-      encoder.outputFormatting = .sortedKeys
-      do {
-        let jsonData = try encoder.encode(variables)
-        keyIdData.append(jsonData)
-      } catch {
-        DataConnectLogger
-          .warning("Error encoding variables to compute request identifier: \(error)")
-      }
-    }
-
-    return keyIdData.sha256String
-  }()
+  lazy var requestId: String = OperationUtils
+    .computeRequestId(operationName: operationName, variables: variables)
 
   init(operationName: String, variables: Variable? = nil) {
     self.operationName = operationName

--- a/Sources/Queries/ObservableQueryRef.swift
+++ b/Sources/Queries/ObservableQueryRef.swift
@@ -66,24 +66,6 @@ public class QueryRefObservableObject<
       grpcClient: grpcClient,
       cache: cache
     )
-    setupSubscription()
-  }
-
-  private func setupSubscription() {
-    Task {
-      resultsCancellable = await baseRef.subscribe()
-        .receive(on: DispatchQueue.main)
-        .sink(receiveValue: { result in
-          switch result {
-          case let .success(operationResult):
-            self.data = operationResult.data
-            self.source = operationResult.source
-            self.lastError = nil
-          case let .failure(dcerror):
-            self.lastError = dcerror.dataConnectError
-          }
-        })
-    }
   }
 
   // ObservableQueryRef implementation
@@ -104,8 +86,16 @@ public class QueryRefObservableObject<
   /// variable
   public func execute(fetchPolicy: QueryFetchPolicy = .preferCache) async throws
     -> OperationResult<ResultData> {
-    let result = try await baseRef.execute(fetchPolicy: fetchPolicy)
-    return result
+    do {
+      let result = try await baseRef.execute(fetchPolicy: fetchPolicy)
+      data = result.data
+      source = result.source
+      lastError = nil
+      return result
+    } catch let error as AnyDataConnectError {
+      self.lastError = error.dataConnectError
+      throw error
+    }
   }
 
   /// Returns the underlying results publisher.
@@ -113,7 +103,20 @@ public class QueryRefObservableObject<
   /// background updates,...)
   public func subscribe() async throws
     -> AnyPublisher<Result<OperationResult<ResultData>, AnyDataConnectError>, Never> {
-    return await baseRef.subscribe()
+    let resultsSub = await baseRef.subscribe()
+    resultsCancellable = resultsSub
+      .receive(on: DispatchQueue.main)
+      .sink(receiveValue: { result in
+        switch result {
+        case let .success(resultData):
+          self.data = resultData.data
+          self.source = resultData.source
+          self.lastError = nil
+        case let .failure(dcerror):
+          self.lastError = dcerror.dataConnectError
+        }
+      })
+    return resultsSub
   }
 }
 
@@ -178,24 +181,6 @@ public class QueryRefObservation<
       grpcClient: grpcClient,
       cache: cache
     )
-    setupSubscription()
-  }
-
-  private func setupSubscription() {
-    Task {
-      resultsCancellable = await baseRef.subscribe()
-        .receive(on: DispatchQueue.main)
-        .sink(receiveValue: { result in
-          switch result {
-          case let .success(resultData):
-            self.data = resultData.data
-            self.source = resultData.source
-            self.lastError = nil
-          case let .failure(dcerror):
-            self.lastError = dcerror.dataConnectError
-          }
-        })
-    }
   }
 
   // ObservableQueryRef implementation
@@ -216,8 +201,16 @@ public class QueryRefObservation<
   /// variable
   public func execute(fetchPolicy: QueryFetchPolicy = .preferCache) async throws
     -> OperationResult<ResultData> {
-    let result = try await baseRef.execute(fetchPolicy: fetchPolicy)
-    return result
+    do {
+      let result = try await baseRef.execute(fetchPolicy: fetchPolicy)
+      data = result.data
+      source = result.source
+      lastError = nil
+      return result
+    } catch let error as AnyDataConnectError {
+      self.lastError = error.dataConnectError
+      throw error
+    }
   }
 
   /// Returns the underlying results publisher.
@@ -225,7 +218,20 @@ public class QueryRefObservation<
   /// background updates,...)
   public func subscribe() async throws
     -> AnyPublisher<Result<OperationResult<ResultData>, AnyDataConnectError>, Never> {
-    return await baseRef.subscribe()
+    let resultsSub = await baseRef.subscribe()
+    resultsCancellable = resultsSub
+      .receive(on: DispatchQueue.main)
+      .sink(receiveValue: { result in
+        switch result {
+        case let .success(resultData):
+          self.data = resultData.data
+          self.source = resultData.source
+          self.lastError = nil
+        case let .failure(dcerror):
+          self.lastError = dcerror.dataConnectError
+        }
+      })
+    return resultsSub
   }
 }
 

--- a/Sources/Queries/QueryRequest.swift
+++ b/Sources/Queries/QueryRequest.swift
@@ -22,26 +22,8 @@ struct QueryRequest<Variable: OperationVariable>: OperationRequest, Hashable, Eq
   private(set) var variables: Variable?
 
   // Computed requestId
-  lazy var requestId: String = {
-    var keyIdData = Data()
-    if let nameData = operationName.data(using: .utf8) {
-      keyIdData.append(nameData)
-    }
-
-    if let variables {
-      let encoder = JSONEncoder()
-      encoder.outputFormatting = .sortedKeys
-      do {
-        let jsonData = try encoder.encode(variables)
-        keyIdData.append(jsonData)
-      } catch {
-        DataConnectLogger
-          .warning("Error encoding variables to compute request identifier: \(error)")
-      }
-    }
-
-    return keyIdData.sha256String
-  }()
+  lazy var requestId: String = OperationUtils
+    .computeRequestId(operationName: operationName, variables: variables)
 
   init(operationName: String, variables: Variable? = nil) {
     self.operationName = operationName


### PR DESCRIPTION
Implement mutation execution on the stream and also fix existing logic so that the stream connection is only opened upon the first `subscribe` call. Before the first `subscribe` call, `execute` calls occur on the unary gRPC client.