### PR TITLE
Handle auth state changes.

### DIFF
--- a/Sources/Internal/StreamingGrpcClient.swift
+++ b/Sources/Internal/StreamingGrpcClient.swift
@@ -37,6 +37,10 @@ actor StreamingGrpcClient: GrpcClient {
   private var reconnectTask: Task<Void, Never>?
   private var responseStreamTask: Task<Void, Never>?
 
+  private var authListenerHandle: AuthStateDidChangeListenerHandle?
+  private var lastKnownUid: String?
+  private var pendingNewToken: String?
+
   private var requestIdSequence: UInt64 = 0
 
   private var nextRequestIdSequence: UInt64 {
@@ -79,6 +83,61 @@ actor StreamingGrpcClient: GrpcClient {
     self.callerSDKType = callerSDKType
     self.googRequestHeaderValue = googRequestHeaderValue
     self.googApiClientHeaderValue = googApiClientHeaderValue
+
+    lastKnownUid = auth.currentUser?.uid
+
+    authListenerHandle = auth.addStateDidChangeListener { [weak self] auth, user in
+      Task { [weak self] in
+        await self?.authStatusChanged(user: user)
+      }
+    }
+  }
+
+  deinit {
+    if let handle = authListenerHandle {
+      auth.removeStateDidChangeListener(handle)
+    }
+  }
+
+  private func authStatusChanged(user: User?) async {
+    let newUid = user?.uid
+    if newUid != lastKnownUid {
+      DataConnectLogger
+        .debug(
+          "Auth identity changed from \(lastKnownUid ?? "nil") to \(newUid ?? "nil"). Reconnecting stream."
+        )
+      lastKnownUid = newUid
+
+      if responseStreamTask != nil {
+        responseStreamTask?.cancel()
+        responseStreamTask = nil
+      }
+      streamingCall = nil
+    } else if let user = user {
+      DataConnectLogger
+        .debug("Auth token refreshed for user \(newUid ?? "nil"). Updating on stream.")
+      do {
+        let token = try await user.getIDToken()
+        let hasSubs = await subManager.hasAnySubscription()
+        if hasSubs {
+          var headerRequest = FirebaseDataConnectStreamRequest()
+          headerRequest.headers["x-firebase-auth-token"] = token
+
+          if let call = streamingCall {
+            try await call.requestStream.send(headerRequest)
+            DataConnectLogger.debug("Sent new auth token on stream.")
+          } else {
+            DataConnectLogger.debug("Stream not active, storing token for next request.")
+            pendingNewToken = token
+          }
+        } else {
+          DataConnectLogger.debug("No active subscriptions, storing token for next request.")
+          pendingNewToken = token
+        }
+      } catch {
+        DataConnectLogger.error("Failed to get ID token: \(error)")
+      }
+    }
   }
 
   func connectStream() async {
@@ -252,6 +311,11 @@ actor StreamingGrpcClient: GrpcClient {
       streamRequest.requestID = "\(seqRequestId)"
       streamRequest.execute = try protoCodec.createStreamExecuteRequest(request: request)
 
+      if let token = pendingNewToken {
+        streamRequest.headers["x-firebase-auth-token"] = token
+        pendingNewToken = nil
+      }
+
       DataConnectLogger
         .debug(
           "Making streaming call with request \(streamRequest.requestID), \(streamRequest.name), \(streamRequest.execute.operationName)"
@@ -308,6 +372,11 @@ actor StreamingGrpcClient: GrpcClient {
       var streamRequest = FirebaseDataConnectStreamRequest()
       streamRequest.requestID = requestID.stringValue
       streamRequest.subscribe = try protoCodec.createStreamExecuteRequest(request: request)
+
+      if let token = pendingNewToken {
+        streamRequest.headers["x-firebase-auth-token"] = token
+        pendingNewToken = nil
+      }
 
       do {
         await subManager.saveRequest(streamRequest, for: requestID, type: RequestType.subscribe)

--- a/Sources/Internal/StreamingGrpcClient.swift
+++ b/Sources/Internal/StreamingGrpcClient.swift
@@ -119,7 +119,7 @@ actor StreamingGrpcClient: GrpcClient {
         let hasSubs = await subManager.hasAnySubscription()
         if hasSubs {
           var headerRequest = FirebaseDataConnectStreamRequest()
-          headerRequest.headers["x-firebase-auth-token"] = token
+          headerRequest.headers[GrpcClientRequestHeaders.firebaseAuthToken] = token
 
           if let call = streamingCall {
             try await call.requestStream.send(headerRequest)
@@ -310,7 +310,7 @@ actor StreamingGrpcClient: GrpcClient {
       streamRequest.execute = try protoCodec.createStreamExecuteRequest(request: request)
 
       if let token = pendingNewToken {
-        streamRequest.headers["x-firebase-auth-token"] = token
+        streamRequest.headers[GrpcClientRequestHeaders.firebaseAuthToken] = token
         pendingNewToken = nil
       }
 
@@ -372,7 +372,7 @@ actor StreamingGrpcClient: GrpcClient {
       streamRequest.subscribe = try protoCodec.createStreamExecuteRequest(request: request)
 
       if let token = pendingNewToken {
-        streamRequest.headers["x-firebase-auth-token"] = token
+        streamRequest.headers[GrpcClientRequestHeaders.firebaseAuthToken] = token
         pendingNewToken = nil
       }
 

--- a/Sources/Internal/StreamingGrpcClient.swift
+++ b/Sources/Internal/StreamingGrpcClient.swift
@@ -103,7 +103,7 @@ actor StreamingGrpcClient: GrpcClient {
     if newUid != currentUid {
       DataConnectLogger
         .debug(
-          "Auth identity changed from \(currentUid ?? "nil") to \(newUid ?? "nil"). Reconnecting stream."
+          "Auth identity changed from \(currentUid ?? "nil") to \(newUid ?? "nil"). Disconnecting stream."
         )
 
       currentUid = newUid

--- a/Sources/Internal/StreamingGrpcClient.swift
+++ b/Sources/Internal/StreamingGrpcClient.swift
@@ -102,11 +102,12 @@ actor StreamingGrpcClient: GrpcClient {
   private func authStatusChanged(user: User?) async {
     let newUid = user?.uid
     if newUid != currentUid {
-      currentUid = newUid
       DataConnectLogger
         .debug(
           "Auth identity changed from \(currentUid ?? "nil") to \(newUid ?? "nil"). Reconnecting stream."
         )
+      currentUid = newUid
+      pendingNewToken = nil
       // This should trigger handleStreamDisconnect(), as the responseStream will also terminate.
       await streamingCall?.requestStream.finish()
     } else if let user = user {

--- a/Sources/Internal/StreamingGrpcClient.swift
+++ b/Sources/Internal/StreamingGrpcClient.swift
@@ -49,6 +49,11 @@ actor StreamingGrpcClient: GrpcClient {
   }
 
   private lazy var streamingClient: FirebaseDataConnectStreamingClient? = {
+    authListenerHandle = auth.addStateDidChangeListener { [weak self] auth, user in
+      Task { [weak self] in
+        await self?.authStatusChanged(user: user)
+      }
+    }
     do {
       DataConnectLogger.debug(
         "StreamingGrpcClient: streaming client initialization starting."
@@ -85,12 +90,6 @@ actor StreamingGrpcClient: GrpcClient {
     self.googApiClientHeaderValue = googApiClientHeaderValue
 
     currentUid = auth.currentUser?.uid
-
-    authListenerHandle = auth.addStateDidChangeListener { [weak self] auth, user in
-      Task { [weak self] in
-        await self?.authStatusChanged(user: user)
-      }
-    }
   }
 
   deinit {
@@ -106,9 +105,11 @@ actor StreamingGrpcClient: GrpcClient {
         .debug(
           "Auth identity changed from \(currentUid ?? "nil") to \(newUid ?? "nil"). Reconnecting stream."
         )
+
       currentUid = newUid
       pendingNewToken = nil
-      // This should trigger handleStreamDisconnect(), as the responseStream will also terminate.
+
+      await subManager.handleAuthStateChange()
       await streamingCall?.requestStream.finish()
     } else if let user = user {
       DataConnectLogger
@@ -593,6 +594,28 @@ actor StreamSubscriptionManager {
           .debug("No continuation found for pending mutation with request ID \(reqId)")
       }
     }
+  }
+
+  func handleAuthStateChange() {
+    for value in subscribeContinuations.values {
+      value.finish()
+    }
+    subscribeContinuations.removeAll()
+    activeSubscribeRequests.removeAll()
+    operationSubs.removeAll()
+
+    let errStr = "Authentication state change occured while waiting for stream response"
+    let failureResponse = OperationFailureResponse(
+      rawJsonData: "",
+      errors: [.init(message: errStr, path: [])],
+      data: nil
+    )
+    for value in executeContinuations.values {
+      value.resume(throwing: DataConnectOperationError.executionFailed(response: failureResponse))
+    }
+    executeContinuations.removeAll()
+    activeQueryExecuteRequests.removeAll()
+    activeMutationExecuteRequests.removeAll()
   }
 
   func handleError(_ error: Error, for reqId: RequestIdentifier) {

--- a/Sources/Internal/StreamingGrpcClient.swift
+++ b/Sources/Internal/StreamingGrpcClient.swift
@@ -38,7 +38,7 @@ actor StreamingGrpcClient: GrpcClient {
   private var responseStreamTask: Task<Void, Never>?
 
   private var authListenerHandle: AuthStateDidChangeListenerHandle?
-  private var lastKnownUid: String?
+  private var currentUid: String?
   private var pendingNewToken: String?
 
   private var requestIdSequence: UInt64 = 0
@@ -84,7 +84,7 @@ actor StreamingGrpcClient: GrpcClient {
     self.googRequestHeaderValue = googRequestHeaderValue
     self.googApiClientHeaderValue = googApiClientHeaderValue
 
-    lastKnownUid = auth.currentUser?.uid
+    currentUid = auth.currentUser?.uid
 
     authListenerHandle = auth.addStateDidChangeListener { [weak self] auth, user in
       Task { [weak self] in
@@ -101,18 +101,14 @@ actor StreamingGrpcClient: GrpcClient {
 
   private func authStatusChanged(user: User?) async {
     let newUid = user?.uid
-    if newUid != lastKnownUid {
+    if newUid != currentUid {
+      currentUid = newUid
       DataConnectLogger
         .debug(
-          "Auth identity changed from \(lastKnownUid ?? "nil") to \(newUid ?? "nil"). Reconnecting stream."
+          "Auth identity changed from \(currentUid ?? "nil") to \(newUid ?? "nil"). Reconnecting stream."
         )
-      lastKnownUid = newUid
-
-      if responseStreamTask != nil {
-        responseStreamTask?.cancel()
-        responseStreamTask = nil
-      }
-      streamingCall = nil
+      // This should trigger handleStreamDisconnect(), as the responseStream will also terminate.
+      await streamingCall?.requestStream.finish()
     } else if let user = user {
       DataConnectLogger
         .debug("Auth token refreshed for user \(newUid ?? "nil"). Updating on stream.")

--- a/Sources/Queries/GenericQueryRef.swift
+++ b/Sources/Queries/GenericQueryRef.swift
@@ -50,6 +50,8 @@ actor GenericQueryRef<ResultData: Decodable & Sendable, Variable: OperationVaria
     -> AnyPublisher<Result<OperationResult<ResultData>, AnyDataConnectError>, Never> {
     Task {
       do {
+        _ = try await fetchCachedResults(allowStale: true)
+
         // if we already have a stream return
         guard self.subscriptionStream == nil else { return }
 

--- a/Sources/Queries/GenericQueryRef.swift
+++ b/Sources/Queries/GenericQueryRef.swift
@@ -73,7 +73,8 @@ actor GenericQueryRef<ResultData: Decodable & Sendable, Variable: OperationVaria
                   ))))
           }
         }
-
+        // Exiting the loop indicates the stream has finished.
+        self.subscriptionStream = nil
       } catch {
         // stream failures
         resultsPublisher


### PR DESCRIPTION
If the authentication changes (signed out -> signed in, signed in -> signed out, change in signed-in user), tear down the stream and discard any active subscribes or executes.

If the authentication token refreshes (same user), send an empty header-only request with the new authentication token.