### PR TITLE
Fix: Cache fails to decode empty root array.

### DIFF
--- a/Sources/Cache/EntityNode.swift
+++ b/Sources/Cache/EntityNode.swift
@@ -120,8 +120,10 @@ struct EntityNode {
           // no point in keeping with query scalars
           // since they get overwritten with every query update
           DataConnectLogger.debug("Empty Array found for key \(key)")
-          if entityData != nil {
-            entityData?.updateServerValue(key, value, impactedRefsAccumulator?.requestorId)
+          if let entityData {
+            entityData.updateServerValue(key, value, impactedRefsAccumulator?.requestorId)
+          } else {
+            scalars[key] = value
           }
         }
       default:

--- a/Sources/Cache/EntityNode.swift
+++ b/Sources/Cache/EntityNode.swift
@@ -115,13 +115,19 @@ struct EntityNode {
             }
           }
         } else {
-          // Since we don't know the type of an empty array
-          // we store it as a scalar with the Entity if present
-          // no point in keeping with query scalars
-          // since they get overwritten with every query update
+          // Since we don't know the type of an empty array,
+          // we store it with the Entity if present (and accumulate impacted refs).
+          // Otherwise, we store it as a query-level scalar.
           DataConnectLogger.debug("Empty Array found for key \(key)")
           if let entityData {
-            entityData.updateServerValue(key, value, impactedRefsAccumulator?.requestorId)
+            let impactedRefs = entityData.updateServerValue(
+              key,
+              value,
+              impactedRefsAccumulator?.requestorId
+            )
+            for r in impactedRefs {
+              impactedRefsAccumulator?.append(r)
+            }
           } else {
             scalars[key] = value
           }

--- a/Sources/Queries/GenericQueryRef.swift
+++ b/Sources/Queries/GenericQueryRef.swift
@@ -50,7 +50,12 @@ actor GenericQueryRef<ResultData: Decodable & Sendable, Variable: OperationVaria
     -> AnyPublisher<Result<OperationResult<ResultData>, AnyDataConnectError>, Never> {
     Task {
       do {
-        _ = try await fetchCachedResults(allowStale: true)
+        
+        do {
+          _ = try await fetchCachedResults(allowStale: true)
+        } catch {
+          DataConnectLogger.debug("Error fetching cached results. Proceeding with server subscribe: \(error)")
+        }
 
         // If we already have a stream return
         guard self.subscriptionStream == nil else { return }

--- a/Sources/Queries/GenericQueryRef.swift
+++ b/Sources/Queries/GenericQueryRef.swift
@@ -50,11 +50,11 @@ actor GenericQueryRef<ResultData: Decodable & Sendable, Variable: OperationVaria
     -> AnyPublisher<Result<OperationResult<ResultData>, AnyDataConnectError>, Never> {
     Task {
       do {
-        
         do {
           _ = try await fetchCachedResults(allowStale: true)
         } catch {
-          DataConnectLogger.debug("Error fetching cached results. Proceeding with server subscribe: \(error)")
+          DataConnectLogger
+            .debug("Error fetching cached results. Proceeding with server subscribe: \(error)")
         }
 
         // If we already have a stream return

--- a/Tests/Unit/CacheTests.swift
+++ b/Tests/Unit/CacheTests.swift
@@ -216,6 +216,24 @@ final class CacheTests: XCTestCase {
         }
       ]}
   """
+  
+  let emptyRootArray = """
+    {
+    "sharedLists":[],
+    "ownedLists":[{"createdAt":"2026-05-04T09:10:45.387765Z","id":"fe36d12a06b146b987f0346f31ea903e","owner":{"email":"test4@gmail.com","id":"UtDFqWXfSBn46yXjAs0b8ok816Rq"},"title":"Test21341234"}]
+    }
+    """
+  
+  let emptyRootArrayExt = """
+    { "dataConnect" : [
+        { "path": ["ownedLists"],
+          "entityIds":["ownedListItem1"] },
+        { "path": ["ownedLists", 0, "owner"],
+          "entityId": "ownerId1" },
+        { "path": ["sharedLists"] }
+      ]
+    }
+    """
 
   var cacheProvider: SQLiteCacheProvider?
 
@@ -358,6 +376,40 @@ final class CacheTests: XCTestCase {
     }
   }
 
+  func testEmptyRootArrayDehydrationHydration() throws {
+    do {
+      let cp = try XCTUnwrap(cacheProvider)
+
+      let jsonDecoder = JSONDecoder()
+      let extResponse = try jsonDecoder.decode(
+        ExtensionResponse.self,
+        from: emptyRootArrayExt.data(using: .utf8)!
+      )
+      let flattenedPaths = extResponse.flattenPathMetadata()
+
+      let resultsProcessor = ResultTreeProcessor()
+
+      let (dehydratedTree, do1, _) = try resultsProcessor.dehydrateResults("queryEmptyRootArray",
+                                                                           emptyRootArray
+                                                                             .data(using: .utf8)!,
+                                                                           flattenedPaths,
+                                                                           cacheProvider: cp)
+
+      let (hydratedResults, do2) = try resultsProcessor.hydrateResults(
+        dehydratedTree,
+        cacheProvider: cp
+      )
+
+      XCTAssertEqual(do1, do2)
+
+      let decodedOriginal = try JSONSerialization.jsonObject(with: emptyRootArray.data(using: .utf8)!, options: []) as? [String: Any]
+      let decodedHydrated = try JSONSerialization.jsonObject(with: hydratedResults, options: []) as? [String: Any]
+
+      XCTAssertEqual(decodedOriginal as NSDictionary?, decodedHydrated as NSDictionary?)
+    }
+  }
+
+
   func testImpactedRefs() throws {
     do {
       let cp = try XCTUnwrap(cacheProvider)
@@ -477,7 +529,9 @@ final class CacheTests: XCTestCase {
       XCTFail()
     }
   }
-
+  
+  
+  
   func testMaxAge() throws {
     let ttl: TimeInterval = 0.2 // 200ms
     let resultTree = ResultTree(

--- a/Tests/Unit/CacheTests.swift
+++ b/Tests/Unit/CacheTests.swift
@@ -216,24 +216,24 @@ final class CacheTests: XCTestCase {
         }
       ]}
   """
-  
+
   let emptyRootArray = """
-    {
-    "sharedLists":[],
-    "ownedLists":[{"createdAt":"2026-05-04T09:10:45.387765Z","id":"fe36d12a06b146b987f0346f31ea903e","owner":{"email":"test4@gmail.com","id":"UtDFqWXfSBn46yXjAs0b8ok816Rq"},"title":"Test21341234"}]
-    }
-    """
-  
+  {
+  "sharedLists":[],
+  "ownedLists":[{"createdAt":"2026-05-04T09:10:45.387765Z","id":"fe36d12a06b146b987f0346f31ea903e","owner":{"email":"test4@gmail.com","id":"UtDFqWXfSBn46yXjAs0b8ok816Rq"},"title":"Test21341234"}]
+  }
+  """
+
   let emptyRootArrayExt = """
-    { "dataConnect" : [
-        { "path": ["ownedLists"],
-          "entityIds":["ownedListItem1"] },
-        { "path": ["ownedLists", 0, "owner"],
-          "entityId": "ownerId1" },
-        { "path": ["sharedLists"] }
-      ]
-    }
-    """
+  { "dataConnect" : [
+      { "path": ["ownedLists"],
+        "entityIds":["ownedListItem1"] },
+      { "path": ["ownedLists", 0, "owner"],
+        "entityId": "ownerId1" },
+      { "path": ["sharedLists"] }
+    ]
+  }
+  """
 
   var cacheProvider: SQLiteCacheProvider?
 
@@ -402,13 +402,18 @@ final class CacheTests: XCTestCase {
 
       XCTAssertEqual(do1, do2)
 
-      let decodedOriginal = try JSONSerialization.jsonObject(with: emptyRootArray.data(using: .utf8)!, options: []) as? [String: Any]
-      let decodedHydrated = try JSONSerialization.jsonObject(with: hydratedResults, options: []) as? [String: Any]
+      let decodedOriginal = try JSONSerialization.jsonObject(
+        with: emptyRootArray.data(using: .utf8)!,
+        options: []
+      ) as? [String: Any]
+      let decodedHydrated = try JSONSerialization.jsonObject(
+        with: hydratedResults,
+        options: []
+      ) as? [String: Any]
 
       XCTAssertEqual(decodedOriginal as NSDictionary?, decodedHydrated as NSDictionary?)
     }
   }
-
 
   func testImpactedRefs() throws {
     do {
@@ -529,9 +534,7 @@ final class CacheTests: XCTestCase {
       XCTFail()
     }
   }
-  
-  
-  
+
   func testMaxAge() throws {
     let ttl: TimeInterval = 0.2 // 200ms
     let resultTree = ResultTree(


### PR DESCRIPTION
If the response contains an empty root array, the cache fails to save it, which results in a decode failure when fetched from cache. 

Since empty root array isn't associated with an EntityDataObject, we simply store it with the EntityNode