### PR TITLE
fix: cache isn't correctly initialized for prod endpoints.

### DIFF
--- a/Sources/DataConnect.swift
+++ b/Sources/DataConnect.swift
@@ -24,7 +24,7 @@ public class DataConnect {
   private(set) var settings: DataConnectSettings
 
   private(set) var grpcClient: GrpcClient
-  private var operationsManager: OperationsManager
+  private(set) var operationsManager: OperationsManager
 
   private(set) var cache: Cache?
 

--- a/Sources/DataConnect.swift
+++ b/Sources/DataConnect.swift
@@ -122,10 +122,11 @@ public class DataConnect {
       callerSDKType: self.callerSDKType
     )
 
-    operationsManager = OperationsManager(grpcClient: grpcClient, cache: cache)
+    operationsManager = OperationsManager(grpcClient: grpcClient)
 
     if let cacheSettings = settings.cacheSettings {
       cache = Cache(config: cacheSettings, dataConnect: self)
+      operationsManager.updateCache(cache: cache)
     }
   }
 

--- a/Sources/Internal/OperationsManager.swift
+++ b/Sources/Internal/OperationsManager.swift
@@ -35,14 +35,14 @@ class OperationsManager {
   /// Updates the cache instance used by the operations manager.
   ///
   /// Note: This method must only be called during initialization before any query references are
-  /// created.
-  ///         Existing query references capture the cache reference at creation time and will not be
+  /// created. Existing query references capture the cache reference at creation time and will not
+  /// be
   /// updated.
   func updateCache(cache: Cache?) {
     accessQueue.sync {
       if queryRefs.count > 0 || mutationRefs.count > 0 {
         DataConnectLogger
-          .warning("WARNING: updateCache must be called before fetching any queries or mutations.")
+          .warning("WARNING: updateCache must be called before creating any queries or mutations.")
       }
 
       self.cache = cache

--- a/Sources/Internal/OperationsManager.swift
+++ b/Sources/Internal/OperationsManager.swift
@@ -20,21 +20,22 @@ class OperationsManager {
 
   private var cache: Cache?
 
-  private let queryRefAccessQueue = DispatchQueue(
-    label: "firebase.dataconnect.queryRef.AccessQ",
+  private let accessQueue = DispatchQueue(
+    label: "firebase.dataconnect.operationsManager.AccessQ",
     autoreleaseFrequency: .workItem
   )
   private var queryRefs = [String: any ObservableQueryRef]()
-
-  private let mutationRefAccessQueue = DispatchQueue(
-    label: "firebase.dataconnect.mutRef.AccessQ",
-    autoreleaseFrequency: .workItem
-  )
   private var mutationRefs = [AnyHashable: any OperationRef]()
 
   init(grpcClient: GrpcClient, cache: Cache? = nil) {
     self.grpcClient = grpcClient
     self.cache = cache
+  }
+
+  func updateCache(cache: Cache?) {
+    accessQueue.sync {
+      self.cache = cache
+    }
   }
 
   func queryRef<ResultDataType: Decodable & Sendable,
@@ -43,7 +44,7 @@ class OperationsManager {
                                        .Type,
                                      publisher: ResultsPublisherType = .auto)
     -> any ObservableQueryRef {
-    queryRefAccessQueue.sync {
+    accessQueue.sync {
       var req = request // requestId is a mutating call.
       let requestId = req.requestId
 
@@ -76,7 +77,7 @@ class OperationsManager {
   }
 
   func queryRef(for operationId: String) -> (any ObservableQueryRef)? {
-    queryRefAccessQueue.sync {
+    accessQueue.sync {
       queryRefs[operationId]
     }
   }
@@ -85,7 +86,7 @@ class OperationsManager {
     VariableType: OperationVariable>(for request: MutationRequest<VariableType>,
                                      with resultType: ResultDataType
                                        .Type) -> MutationRef<ResultDataType, VariableType> {
-    mutationRefAccessQueue.sync {
+    accessQueue.sync {
       if let ref = mutationRefs[
         AnyHashable(
           request

--- a/Sources/Internal/OperationsManager.swift
+++ b/Sources/Internal/OperationsManager.swift
@@ -36,8 +36,7 @@ class OperationsManager {
   ///
   /// Note: This method must only be called during initialization before any query references are
   /// created. Existing query references capture the cache reference at creation time and will not
-  /// be
-  /// updated.
+  /// be updated.
   func updateCache(cache: Cache?) {
     accessQueue.sync {
       if queryRefs.count > 0 || mutationRefs.count > 0 {

--- a/Sources/Internal/OperationsManager.swift
+++ b/Sources/Internal/OperationsManager.swift
@@ -18,7 +18,7 @@ import Foundation
 class OperationsManager {
   private var grpcClient: GrpcClient
 
-  private var cache: Cache?
+  private(set) var cache: Cache?
 
   private let accessQueue = DispatchQueue(
     label: "firebase.dataconnect.operationsManager.AccessQ",
@@ -32,8 +32,19 @@ class OperationsManager {
     self.cache = cache
   }
 
+  /// Updates the cache instance used by the operations manager.
+  ///
+  /// Note: This method must only be called during initialization before any query references are
+  /// created.
+  ///         Existing query references capture the cache reference at creation time and will not be
+  /// updated.
   func updateCache(cache: Cache?) {
     accessQueue.sync {
+      if queryRefs.count > 0 || mutationRefs.count > 0 {
+        DataConnectLogger
+          .warning("WARNING: updateCache must be called before fetching any queries or mutations.")
+      }
+
       self.cache = cache
     }
   }

--- a/Tests/Unit/CacheTests.swift
+++ b/Tests/Unit/CacheTests.swift
@@ -15,6 +15,7 @@
 import Foundation
 import XCTest
 
+import FirebaseCore
 @testable import FirebaseDataConnect
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Tests/Unit/InstanceTests.swift
+++ b/Tests/Unit/InstanceTests.swift
@@ -296,4 +296,36 @@ class InstanceTests: XCTestCase {
 
     XCTAssertTrue(refOne !== refTwo)
   }
+
+  func testCacheInitializedAndAvailableToQueryRefsWhenEmulatorNotUsed() throws {
+    let cacheSettings = CacheSettings(storage: .memory)
+    let settings = DataConnectSettings(cacheSettings: cacheSettings)
+
+    let dc = DataConnect.dataConnect(
+      app: InstanceTests.defaultApp!,
+      connectorConfig: fakeConnectorConfigOne,
+      settings: settings
+    )
+
+    // Confirm DataConnect cache is initialized
+    XCTAssertNotNil(dc.cache)
+
+    // Confirm OperationsManager cache is initialized and matches
+    XCTAssertNotNil(dc.operationsManager.cache)
+    XCTAssertTrue(dc.cache === dc.operationsManager.cache)
+
+    // Confirm that created QueryRefs have access to the cache
+    let queryName = "someQuery"
+    let variable = VariableTypeOne(email: "aa@g.com", handle: "aa@", someNumber: 12345)
+
+    let ref = dc.query(
+      name: queryName,
+      variables: variable,
+      resultsDataType: Int.self,
+      publisher: .observableObject
+    ) as! QueryRefObservableObject<Int, VariableTypeOne>
+
+    // Assert that QueryRef is successfully created
+    XCTAssertNotNil(ref)
+  }
 }

--- a/Tests/Unit/InstanceTests.swift
+++ b/Tests/Unit/InstanceTests.swift
@@ -297,13 +297,43 @@ class InstanceTests: XCTestCase {
     XCTAssertTrue(refOne !== refTwo)
   }
 
+  // we configure a separate app, connector config for caching
+  // otherwise it returns a FDC instance configured elsewhere in tests
+  // which has no cache.
+  func cacheApp() -> FirebaseApp {
+    let appName = "cache-app"
+
+    guard FirebaseApp.app(name: appName) == nil else {
+      return FirebaseApp.app(name: appName)!
+    }
+
+    FirebaseApp.configure(name: appName, options: optionsCache)
+    return FirebaseApp.app(name: appName)!
+  }
+
+  var optionsCache: FirebaseOptions = {
+    let optionsTwo = FirebaseOptions(
+      googleAppID: "0:0000000000003:ios:0000000000000002",
+      gcmSenderID: "00000000000000000-00000000000-000000001"
+    )
+    optionsTwo.projectID = "fdc-test-cache"
+    optionsTwo.apiKey = "testDummyApiKey2-cache"
+    return optionsTwo
+  }()
+
+  var fakeConnectorConfigCache = ConnectorConfig(
+    serviceId: "dataconnect",
+    location: "us-central1",
+    connector: "kitchensink-caching"
+  )
+
   func testCacheInitializedAndAvailableToQueryRefsWhenEmulatorNotUsed() throws {
     let cacheSettings = CacheSettings(storage: .memory)
     let settings = DataConnectSettings(cacheSettings: cacheSettings)
 
     let dc = DataConnect.dataConnect(
-      app: InstanceTests.defaultApp!,
-      connectorConfig: fakeConnectorConfigOne,
+      app: cacheApp(),
+      connectorConfig: fakeConnectorConfigCache,
       settings: settings
     )
 


### PR DESCRIPTION
Prod initialization sequence doesn't initialize the OperationsManager with cache. 

