### PR TITLE
fix: Potential race when initializing cache.

### DIFF
--- a/Sources/Cache/Cache.swift
+++ b/Sources/Cache/Cache.swift
@@ -66,11 +66,12 @@ actor Cache {
       return
     }
 
-    authChangeListenerProtocol = Auth.auth(app: dataConnect.app).addStateDidChangeListener { [weak self] _, _ in
-      Task {
-        await self?.initializeCacheProvider()
+    authChangeListenerProtocol = Auth.auth(app: dataConnect.app)
+      .addStateDidChangeListener { [weak self] _, _ in
+        Task {
+          await self?.initializeCacheProvider()
+        }
       }
-    }
   }
 
   // Create an identifier for the cache that the Provider will use for cache scoping

--- a/Sources/Cache/Cache.swift
+++ b/Sources/Cache/Cache.swift
@@ -25,13 +25,17 @@ actor Cache {
   // holding it to avoid dealloc
   private var authChangeListenerProtocol: NSObjectProtocol?
 
+  private class TaskHolder: @unchecked Sendable {
+    var task: Task<Void, Never>?
+  }
+
+  private let setupTaskHolder = TaskHolder()
+
   init(config: CacheSettings, dataConnect: DataConnect) {
     self.config = config
     self.dataConnect = dataConnect
 
-    // this is a potential race since update or get could get scheduled before initialize
-    // workarounds are complex since caller DataConnect APIs aren't async
-    Task {
+    setupTaskHolder.task = Task {
       await initializeCacheProvider()
       await setupChangeListeners()
     }
@@ -98,7 +102,9 @@ actor Cache {
     return identifier
   }
 
-  func resultTree(queryId: String, allowStale: Bool = false) -> ResultTree? {
+  func resultTree(queryId: String, allowStale: Bool = false) async -> ResultTree? {
+    _ = await setupTaskHolder.task?.value
+
     // result trees are stored dehydrated in the cache
     // retrieve cache, hydrate it and then return
     guard let cacheProvider else {
@@ -136,7 +142,13 @@ actor Cache {
     }
   }
 
-  func update(queryId: String, response: ServerResponse, requestor: (any QueryRefInternal)? = nil) {
+  func update(
+    queryId: String,
+    response: ServerResponse,
+    requestor: (any QueryRefInternal)? = nil
+  ) async {
+    _ = await setupTaskHolder.task?.value
+
     // server response contains hydrated trees
     // dehydrate (normalize) the results and store dehydrated trees
     guard let cacheProvider = cacheProvider else {

--- a/Sources/Cache/Cache.swift
+++ b/Sources/Cache/Cache.swift
@@ -25,20 +25,12 @@ actor Cache {
   // holding it to avoid dealloc
   private var authChangeListenerProtocol: NSObjectProtocol?
 
-  private class TaskHolder: @unchecked Sendable {
-    var task: Task<Void, Never>?
-  }
-
-  private let setupTaskHolder = TaskHolder()
-
   init(config: CacheSettings, dataConnect: DataConnect) {
     self.config = config
     self.dataConnect = dataConnect
 
-    setupTaskHolder.task = Task {
-      await initializeCacheProvider()
-      await setupChangeListeners()
-    }
+    initializeCacheProvider()
+    setupChangeListeners()
   }
 
   private func initializeCacheProvider() {
@@ -74,8 +66,10 @@ actor Cache {
       return
     }
 
-    authChangeListenerProtocol = Auth.auth(app: dataConnect.app).addStateDidChangeListener { _, _ in
-      self.initializeCacheProvider()
+    authChangeListenerProtocol = Auth.auth(app: dataConnect.app).addStateDidChangeListener { [weak self] _, _ in
+      Task {
+        await self?.initializeCacheProvider()
+      }
     }
   }
 
@@ -103,8 +97,6 @@ actor Cache {
   }
 
   func resultTree(queryId: String, allowStale: Bool = false) async -> ResultTree? {
-    _ = await setupTaskHolder.task?.value
-
     // result trees are stored dehydrated in the cache
     // retrieve cache, hydrate it and then return
     guard let cacheProvider else {
@@ -147,8 +139,6 @@ actor Cache {
     response: ServerResponse,
     requestor: (any QueryRefInternal)? = nil
   ) async {
-    _ = await setupTaskHolder.task?.value
-
     // server response contains hydrated trees
     // dehydrate (normalize) the results and store dehydrated trees
     guard let cacheProvider = cacheProvider else {


### PR DESCRIPTION
Some setup tasks in the Cache actor were being done in an unawaited task resulting in a race when accessing cache on startup. 