### PR TITLE
fix: Regression to ObservableObject implementation of QueryRef

### DIFF
--- a/Sources/Queries/ObservableQueryRef.swift
+++ b/Sources/Queries/ObservableQueryRef.swift
@@ -90,6 +90,9 @@ public class QueryRefObservableObject<
     -> OperationResult<ResultData> {
     do {
       let result = try await baseRef.execute(fetchPolicy: fetchPolicy)
+      data = result.data
+      source = result.source
+      lastError = nil
       return result
     } catch let error as AnyDataConnectError {
       self.lastError = error.dataConnectError


### PR DESCRIPTION
ObservableObject implementation of QueryRef doesn't publish to Published properties in absence of realtime. 