### PR TITLE
Fix LocalDate digit shaping on non-Latin device regions

### DIFF
--- a/Sources/Scalars/LocalDate.swift
+++ b/Sources/Scalars/LocalDate.swift
@@ -66,6 +66,7 @@ public struct LocalDate: Codable, Comparable, CustomStringConvertible, Equatable
 
   private func setupDateFormat() {
     dateFormatter.dateFormat = "yyyy-MM-dd"
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
   }
 
   private func convert(dateString: String) throws -> Date {


### PR DESCRIPTION
LocalDate's internal DateFormatter was not pinning a locale, so on devices whose Locale.autoupdatingCurrent shapes digits as Arabic-Indic / Persian-Indic / Devanagari (Saudi Arabia, Egypt, Iran, India, etc.), the encoded string violated the ISO-8601 YYYY-MM-DD contract — e.g. "٢٠٢٦-٠٦-٠١" instead of "2026-06-01" — and the backend rejected every query with a LocalDate parameter.

This pins the formatter to en_US_POSIX, which is Apple's documented locale for fixed-format ISO-8601 strings:
https://developer.apple.com/library/archive/qa/qa1480/_index.html

No behavior change for any other locale; the output is now unconditionally Latin digits, matching the type's documented purpose.

Fixes firebase/firebase-ios-sdk#16236