### PR TITLE
fix: Reduce log level for Timestamp decoders since it is quite noisy.

### DIFF
--- a/Sources/Internal/CodableTimestamp.swift
+++ b/Sources/Internal/CodableTimestamp.swift
@@ -52,7 +52,7 @@ extension CodableTimestamp {
       .firstMatch(in: timestampString, range: NSRange(location: 0,
                                                       length: timestampString.count)) !=
       nil else {
-      DataConnectLogger.error(
+      DataConnectLogger.debug(
         "Timestamp string format \(timestampString) is not supported."
       )
       throw DataConnectCodecError.invalidTimestampFormat()


### PR DESCRIPTION
Since decoding failures are used to check for incorrect format using the try? pattern, it can lead to noisy logs. 

Fixes - #106 