### PR TITLE
fix: dataConnect key in ExtensionResponse can be optional

### DIFF
--- a/Sources/Internal/ServerResponse.swift
+++ b/Sources/Internal/ServerResponse.swift
@@ -37,9 +37,13 @@ struct ExtensionResponse: Decodable {
   }
 
   let maxAge: TimeInterval?
-  let dataConnect: [PathMetadataResponse]
+  let dataConnect: [PathMetadataResponse]?
 
   func flattenPathMetadata() -> [DataConnectPath: PathMetadata] {
+    guard let dataConnect else {
+      return [:]
+    }
+
     var result: [DataConnectPath: PathMetadata] = [:]
     for pmr in dataConnect {
       if let entityId = pmr.entityId {


### PR DESCRIPTION
The dataConnect key can be missing in ExtensionResponse. 

Fixes - #109 