### PR TITLE
GrpcClient.swift: add "X-Client-Platform" and "X-Client-Version" headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [added] Add grpc request headers for platform name and sdk version to enable metrics collection in cloud monitoring.
+
 # 11.12.5
 - [fixed] Improved caching performance especially for large result sets.
 

--- a/Sources/Internal/GrpcClient.swift
+++ b/Sources/Internal/GrpcClient.swift
@@ -56,6 +56,8 @@ enum GrpcClientRequestHeaders {
   static let firebaseAppCheckToken = "x-firebase-appcheck"
   static let firebaseAppId = "x-firebase-gmpid"
   static let googApiClient = "x-goog-api-client"
+  static let clientPlatform = "x-client-platform"
+  static let clientVersion = "x-client-version"
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -284,6 +286,8 @@ actor DataConnectGrpcClient: GrpcClient, CustomStringConvertible {
       )
       headers.add(name: GrpcClientRequestHeaders.firebaseAppId, value: app.options.googleAppID)
       headers.add(name: GrpcClientRequestHeaders.googApiClient, value: googApiClientHeaderValue)
+      headers.add(name: GrpcClientRequestHeaders.clientPlatform, value: "ios")
+      headers.add(name: GrpcClientRequestHeaders.clientVersion, value: Version.sdkVersion)
     }
 
     // Add Auth token if available

--- a/Tests/Unit/HeaderTests.swift
+++ b/Tests/Unit/HeaderTests.swift
@@ -88,4 +88,24 @@ final class HeaderTests: XCTestCase {
       }
     XCTAssertTrue(contains)
   }
+
+  func testClientPlatformHeader() async throws {
+    let dcOne = DataConnect.dataConnect(connectorConfig: fakeConnectorConfigOne)
+    let callOptions = await dcOne.grpcClient.createCallOptions()
+    let values = callOptions.customMetadata.values(
+      forHeader: GrpcClientRequestHeaders.clientPlatform, canonicalForm: false
+    )
+    let contains = values.contains { $0 == "ios" }
+    XCTAssertTrue(contains)
+  }
+
+  func testClientVersionHeader() async throws {
+    let dcOne = DataConnect.dataConnect(connectorConfig: fakeConnectorConfigOne)
+    let callOptions = await dcOne.grpcClient.createCallOptions()
+    let values = callOptions.customMetadata.values(
+      forHeader: GrpcClientRequestHeaders.clientVersion, canonicalForm: false
+    )
+    let contains = values.contains { $0 == Version.sdkVersion }
+    XCTAssertTrue(contains)
+  }
 }


### PR DESCRIPTION
This PR adds `x-client-platform` and `x-client-version` gRPC request headers to the Firebase Data Connect iOS SDK. These headers supply the client platform (`ios`) and SDK version (`Version.sdkVersion`) to enable metrics collection in Cloud Monitoring.

**NOTE**: Shortly after merging this PR, it was decided to delete the `x-client-platform` header and merge its value into `x-client-version`. See https://github.com/firebase/data-connect-ios-sdk/pull/116 for details.

### Highlights

* **New gRPC Metadata Headers**: Added `x-client-platform` (set to `"ios"`) and `x-client-version` (set to `Version.sdkVersion`) headers to `GrpcClientRequestHeaders` and attached them to `CallOptions` in `DataConnectGrpcClient.createCallOptions`.
* **Unit Tests**: Added unit tests in `HeaderTests.swift` to verify `x-client-platform` and `x-client-version` header creation.
* **Changelog Entry**: Added an entry in `CHANGELOG.md` documenting the new request headers for Cloud Monitoring metrics.

<details>

<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Added an entry under `Unreleased` for adding gRPC request headers for platform name and SDK version.
* **GrpcClient.swift**
  * Added `clientPlatform` and `clientVersion` header constants to `GrpcClientRequestHeaders` and attached them to `CallOptions` in `createCallOptions`.
* **HeaderTests.swift**
  * Added `testClientPlatformHeader()` and `testClientVersionHeader()` unit tests.
</details>
