### PR TITLE
GrpcClient.swift: add "X-Firebase-Sqlconnect-Affinity" header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [added] Add grpc request headers for platform name and sdk version to enable metrics collection in cloud monitoring.
+- [added] Add grpc request headers for SQL Connect server affinity, to improve server resource usage efficiency and performance.
 
 # 11.12.5
 - [fixed] Improved caching performance especially for large result sets.

--- a/Sources/Internal/GrpcClient.swift
+++ b/Sources/Internal/GrpcClient.swift
@@ -58,6 +58,7 @@ enum GrpcClientRequestHeaders {
   static let googApiClient = "x-goog-api-client"
   static let clientPlatform = "x-client-platform"
   static let clientVersion = "x-client-version"
+  static let sqlConnectAffinity = "x-firebase-sqlconnect-affinity"
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -113,6 +114,7 @@ actor DataConnectGrpcClient: GrpcClient, CustomStringConvertible {
     let connectorName =
       "projects/\(projectId)/locations/\(connectorConfig.location)/services/\(connectorConfig.serviceId)/connectors/\(connectorConfig.connector)"
     let googRequestHeaderValue = "location=\(connectorConfig.location)&frontend=data"
+    let sqlConnectAffinityHeaderValue = "\(projectId)\(connectorConfig.serviceId)"
 
     let header =
       "gl-swift/\(Version.swiftVersion()) fire/\(Version.sdkVersion) \(Version.platformVersionHeader()) grpc-swift/"
@@ -146,7 +148,8 @@ actor DataConnectGrpcClient: GrpcClient, CustomStringConvertible {
       appCheck: appCheck,
       callerSDKType: callerSDKType,
       googRequestHeaderValue: googRequestHeaderValue,
-      googApiClientHeaderValue: googApiClientHeaderValue
+      googApiClientHeaderValue: googApiClientHeaderValue,
+      sqlConnectAffinityHeaderValue: sqlConnectAffinityHeaderValue
     )
 
     streamingClient = StreamingGrpcClient(
@@ -157,7 +160,8 @@ actor DataConnectGrpcClient: GrpcClient, CustomStringConvertible {
       appCheck: appCheck,
       callerSDKType: callerSDKType,
       googRequestHeaderValue: googRequestHeaderValue,
-      googApiClientHeaderValue: googApiClientHeaderValue
+      googApiClientHeaderValue: googApiClientHeaderValue,
+      sqlConnectAffinityHeaderValue: sqlConnectAffinityHeaderValue
     )
   }
 
@@ -276,7 +280,8 @@ actor DataConnectGrpcClient: GrpcClient, CustomStringConvertible {
                                 auth: Auth,
                                 appCheck: AppCheckInterop?,
                                 googRequestHeaderValue: String,
-                                googApiClientHeaderValue: String) async -> CallOptions {
+                                googApiClientHeaderValue: String,
+                                sqlConnectAffinityHeaderValue: String) async -> CallOptions {
     var headers = HPACKHeaders()
 
     if app.isDataCollectionDefaultEnabled {
@@ -288,6 +293,10 @@ actor DataConnectGrpcClient: GrpcClient, CustomStringConvertible {
       headers.add(name: GrpcClientRequestHeaders.googApiClient, value: googApiClientHeaderValue)
       headers.add(name: GrpcClientRequestHeaders.clientPlatform, value: "ios")
       headers.add(name: GrpcClientRequestHeaders.clientVersion, value: Version.sdkVersion)
+      headers.add(
+        name: GrpcClientRequestHeaders.sqlConnectAffinity,
+        value: sqlConnectAffinityHeaderValue
+      )
     }
 
     // Add Auth token if available

--- a/Sources/Internal/StreamingGrpcClient.swift
+++ b/Sources/Internal/StreamingGrpcClient.swift
@@ -31,6 +31,7 @@ actor StreamingGrpcClient: GrpcClient {
   private let callerSDKType: CallerSDKType
   private let googRequestHeaderValue: String
   private let googApiClientHeaderValue: String
+  private let sqlConnectAffinityHeaderValue: String
 
   private var streamingCall: FirebaseDataConnectStreamingCall?
   private let subManager = StreamSubscriptionManager()
@@ -80,7 +81,8 @@ actor StreamingGrpcClient: GrpcClient {
        appCheck: AppCheckInterop?,
        callerSDKType: CallerSDKType,
        googRequestHeaderValue: String,
-       googApiClientHeaderValue: String) {
+       googApiClientHeaderValue: String,
+       sqlConnectAffinityHeaderValue: String) {
     self.app = app
     self.connectorName = connectorName
     self.serverSettings = serverSettings
@@ -89,6 +91,7 @@ actor StreamingGrpcClient: GrpcClient {
     self.callerSDKType = callerSDKType
     self.googRequestHeaderValue = googRequestHeaderValue
     self.googApiClientHeaderValue = googApiClientHeaderValue
+    self.sqlConnectAffinityHeaderValue = sqlConnectAffinityHeaderValue
 
     currentUid = auth.currentUser?.uid
 
@@ -480,7 +483,8 @@ actor StreamingGrpcClient: GrpcClient {
       auth: auth,
       appCheck: appCheck,
       googRequestHeaderValue: googRequestHeaderValue,
-      googApiClientHeaderValue: googApiClientHeaderValue
+      googApiClientHeaderValue: googApiClientHeaderValue,
+      sqlConnectAffinityHeaderValue: sqlConnectAffinityHeaderValue
     )
   }
 }

--- a/Sources/Internal/UnaryGrpcClient.swift
+++ b/Sources/Internal/UnaryGrpcClient.swift
@@ -30,6 +30,7 @@ actor UnaryGrpcClient: GrpcClient {
   private let callerSDKType: CallerSDKType
   private let googRequestHeaderValue: String
   private let googApiClientHeaderValue: String
+  private let sqlConnectAffinityHeaderValue: String
 
   private lazy var unaryClient: FirebaseDataConnectUnaryClient? = {
     do {
@@ -53,7 +54,8 @@ actor UnaryGrpcClient: GrpcClient {
        appCheck: AppCheckInterop?,
        callerSDKType: CallerSDKType,
        googRequestHeaderValue: String,
-       googApiClientHeaderValue: String) {
+       googApiClientHeaderValue: String,
+       sqlConnectAffinityHeaderValue: String) {
     self.app = app
     self.connectorName = connectorName
     self.serverSettings = serverSettings
@@ -62,6 +64,7 @@ actor UnaryGrpcClient: GrpcClient {
     self.callerSDKType = callerSDKType
     self.googRequestHeaderValue = googRequestHeaderValue
     self.googApiClientHeaderValue = googApiClientHeaderValue
+    self.sqlConnectAffinityHeaderValue = sqlConnectAffinityHeaderValue
   }
 
   func executeQuery<
@@ -267,7 +270,8 @@ actor UnaryGrpcClient: GrpcClient {
       auth: auth,
       appCheck: appCheck,
       googRequestHeaderValue: googRequestHeaderValue,
-      googApiClientHeaderValue: googApiClientHeaderValue
+      googApiClientHeaderValue: googApiClientHeaderValue,
+      sqlConnectAffinityHeaderValue: sqlConnectAffinityHeaderValue
     )
   }
 }

--- a/Tests/Unit/HeaderTests.swift
+++ b/Tests/Unit/HeaderTests.swift
@@ -108,4 +108,14 @@ final class HeaderTests: XCTestCase {
     let contains = values.contains { $0 == Version.sdkVersion }
     XCTAssertTrue(contains)
   }
+
+  func testSqlConnectAffinityHeader() async throws {
+    let dcOne = DataConnect.dataConnect(connectorConfig: fakeConnectorConfigOne)
+    let callOptions = await dcOne.grpcClient.createCallOptions()
+    let values = callOptions.customMetadata.values(
+      forHeader: GrpcClientRequestHeaders.sqlConnectAffinity, canonicalForm: false
+    )
+    let contains = values.contains { $0 == "fdc-testdataconnect" }
+    XCTAssertTrue(contains)
+  }
 }


### PR DESCRIPTION
This PR adds the `X-Firebase-SqlConnect-Affinity` gRPC request header to outgoing Data Connect gRPC requests. This header enables backend server affinity routing for SQL Connect to improve server resource usage efficiency and performance.

### Highlights

* **SQL Connect Server Affinity Header**: Added the `X-Firebase-SqlConnect-Affinity` header containing `\(projectId)\(connectorConfig.serviceId)` to gRPC request call options.
* **Unit Test Coverage**: Added `testSqlConnectAffinityHeader()` to `HeaderTests` to verify the header key and formatted value in `createCallOptions()`.

<details>

<summary><b>Changelog</b></summary>

* **CHANGELOG.md**
  * Added unreleased entry for the SQL Connect server affinity header.
* **GrpcClient.swift**
  * Added `sqlConnectAffinity` header key constant to `GrpcClientRequestHeaders`.
  * Computed `sqlConnectAffinityHeaderValue` in `DataConnectGrpcClient.init` and passed it to client implementations.
  * Added `X-Firebase-SqlConnect-Affinity` header in `createCallOptions`.
* **StreamingGrpcClient.swift**
  * Updated initializer and `createCallOptions` to accept and pass `sqlConnectAffinityHeaderValue`.
* **UnaryGrpcClient.swift**
  * Updated initializer and `createCallOptions` to accept and pass `sqlConnectAffinityHeaderValue`.
* **HeaderTests.swift**
  * Added `testSqlConnectAffinityHeader` unit test.
</details>
