### PR TITLE
GrpcClient.swift: merge "X-Client-Platform" header into "X-Client-Version"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [added] Add grpc request headers for platform name and sdk version to enable metrics collection in cloud monitoring.
+- [added] Add grpc request header for platform name and sdk version to enable metrics collection in cloud monitoring.
 
 # 11.12.5
 - [fixed] Improved caching performance especially for large result sets.

--- a/Sources/Internal/GrpcClient.swift
+++ b/Sources/Internal/GrpcClient.swift
@@ -56,7 +56,6 @@ enum GrpcClientRequestHeaders {
   static let firebaseAppCheckToken = "x-firebase-appcheck"
   static let firebaseAppId = "x-firebase-gmpid"
   static let googApiClient = "x-goog-api-client"
-  static let clientPlatform = "x-client-platform"
   static let clientVersion = "x-client-version"
 }
 
@@ -286,8 +285,10 @@ actor DataConnectGrpcClient: GrpcClient, CustomStringConvertible {
       )
       headers.add(name: GrpcClientRequestHeaders.firebaseAppId, value: app.options.googleAppID)
       headers.add(name: GrpcClientRequestHeaders.googApiClient, value: googApiClientHeaderValue)
-      headers.add(name: GrpcClientRequestHeaders.clientPlatform, value: "ios")
-      headers.add(name: GrpcClientRequestHeaders.clientVersion, value: Version.sdkVersion)
+      headers.add(
+        name: GrpcClientRequestHeaders.clientVersion,
+        value: "ios/\(Version.sdkVersion)"
+      )
     }
 
     // Add Auth token if available

--- a/Tests/Unit/HeaderTests.swift
+++ b/Tests/Unit/HeaderTests.swift
@@ -89,23 +89,13 @@ final class HeaderTests: XCTestCase {
     XCTAssertTrue(contains)
   }
 
-  func testClientPlatformHeader() async throws {
-    let dcOne = DataConnect.dataConnect(connectorConfig: fakeConnectorConfigOne)
-    let callOptions = await dcOne.grpcClient.createCallOptions()
-    let values = callOptions.customMetadata.values(
-      forHeader: GrpcClientRequestHeaders.clientPlatform, canonicalForm: false
-    )
-    let contains = values.contains { $0 == "ios" }
-    XCTAssertTrue(contains)
-  }
-
   func testClientVersionHeader() async throws {
     let dcOne = DataConnect.dataConnect(connectorConfig: fakeConnectorConfigOne)
     let callOptions = await dcOne.grpcClient.createCallOptions()
     let values = callOptions.customMetadata.values(
       forHeader: GrpcClientRequestHeaders.clientVersion, canonicalForm: false
     )
-    let contains = values.contains { $0 == Version.sdkVersion }
+    let contains = values.contains { $0 == "ios/\(Version.sdkVersion)" }
     XCTAssertTrue(contains)
   }
 }


### PR DESCRIPTION
This PR updates the gRPC metadata in by merging the `X-Client-Platform` header into the `X-Client-Version` header (formatting as `ios/<version>`) and removing the standalone `X-Client-Platform` header.

This is an update to PR https://github.com/firebase/data-connect-ios-sdk/pull/113 which was merged yesterday and added both of these headers. This update was made to accommodate the firebase-js-sdk because the "X-Client-Platform" header causes the CORS OPTIONS preflight request to fail with a 403 "Permission Denied" error due to that header being absent from Google's list of whitelisted CORS headers. See https://github.com/firebase/firebase-js-sdk/pull/10217 for a few more details, if interested.

### Highlights

* **Header Consolidation**: Merged the platform identifier into the `X-Client-Version` header (e.g. `ios/<version>`) and removed the separate `X-Client-Platform` (`x-client-platform`) header.
* **Test Updates**: Updated test suites to verify the new `X-Client-Version` header value format.
